### PR TITLE
names: make snippets non-capturing

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -12,8 +12,8 @@ const MachineTagKind = "machine"
 
 const (
 	ContainerTypeSnippet = "[a-z]+"
-	ContainerSnippet     = "(/" + ContainerTypeSnippet + "/" + NumberSnippet + ")"
-	MachineSnippet       = NumberSnippet + ContainerSnippet + "*"
+	ContainerSnippet     = "/" + ContainerTypeSnippet + "/" + NumberSnippet + ""
+	MachineSnippet       = NumberSnippet + "(?:" + ContainerSnippet + ")*"
 )
 
 var validMachine = regexp.MustCompile("^" + MachineSnippet + "$")

--- a/relation.go
+++ b/relation.go
@@ -11,7 +11,7 @@ import (
 
 const RelationTagKind = "relation"
 
-const RelationSnippet = "[a-z][a-z0-9]*([_-][a-z0-9]+)*"
+const RelationSnippet = "[a-z][a-z0-9]*(?:[_-][a-z0-9]+)*"
 
 // Relation keys have the format "service1:relName1 service2:relName2".
 // Except the peer relations, which have the format "service:relName"

--- a/service.go
+++ b/service.go
@@ -10,8 +10,8 @@ import (
 const ServiceTagKind = "service"
 
 const (
-	ServiceSnippet = "([a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*)"
-	NumberSnippet  = "(0|[1-9][0-9]*)"
+	ServiceSnippet = "(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)"
+	NumberSnippet  = "(?:0|[1-9][0-9]*)"
 )
 
 var validService = regexp.MustCompile("^" + ServiceSnippet + "$")

--- a/snippet_test.go
+++ b/snippet_test.go
@@ -1,0 +1,33 @@
+package names
+
+import (
+	"strings"
+
+	gc "launchpad.net/gocheck"
+)
+
+var snippets = []struct {
+	name    string
+	snippet string
+}{
+	{"ContainerTypeSnippet", ContainerTypeSnippet},
+	{"ContainerSnippet", ContainerSnippet},
+	{"MachineSnippet", MachineSnippet},
+	{"NumberSnippet", NumberSnippet},
+	{"ServiceSnippet", ServiceSnippet},
+	{"RelationSnippet", RelationSnippet},
+}
+
+type snippetSuite struct{}
+
+var _ = gc.Suite(&snippetSuite{})
+
+func (s *equalitySuite) TestSnippetsContainNoCapturingGroups(c *gc.C) {
+	for _, test := range snippets {
+		for i, ch := range test.snippet {
+			if ch == '(' && !strings.HasPrefix(test.snippet[i:], "(?:") {
+				c.Errorf("%s (%q) contains capturing group", test.name, test.snippet)
+			}
+		}
+	}
+}

--- a/unit.go
+++ b/unit.go
@@ -11,7 +11,7 @@ import (
 
 const UnitTagKind = "unit"
 
-var validUnit = regexp.MustCompile("^" + ServiceSnippet + "/" + NumberSnippet + "$")
+var validUnit = regexp.MustCompile("^(" + ServiceSnippet + ")/" + NumberSnippet + "$")
 
 type UnitTag struct {
 	name string


### PR DESCRIPTION
As discussed online, this makes snippets more useful for 3rd party code.
