### PR TITLE
Export network regexp.

### DIFF
--- a/network.go
+++ b/network.go
@@ -10,11 +10,11 @@ import (
 
 const NetworkTagKind = "network"
 
-var validNetwork = regexp.MustCompile("^([a-z0-9]+(-[a-z0-9]+)*)$")
+var ValidNetwork = regexp.MustCompile("^([a-z0-9]+(-[a-z0-9]+)*)$")
 
 // IsNetwork reports whether name is a valid network name.
 func IsNetwork(name string) bool {
-	return validNetwork.MatchString(name)
+	return ValidNetwork.MatchString(name)
 }
 
 type NetworkTag struct {


### PR DESCRIPTION
Make the valid network regular expression public.

The regular expression for a valid machine id is already public and both will be used in juju to parse a ports document id which is of the format 'm#<machine_id>#n#network_id'.
