### PR TITLE
Consolidate ActionTag and ActionResultTag...

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -217,3 +217,29 @@ func (s *actionSuite) TestParseActionResultTag(c *gc.C) {
 		c.Check(got, gc.Equals, t.expected)
 	}
 }
+
+func (s *actionSuite) TestPrefixSuffix(c *gc.C) {
+	var tests = []struct {
+		prefix string
+		suffix int
+	}{
+		{prefix: "asdf", suffix: 0},
+		{prefix: "qwer/0", suffix: 10},
+		{prefix: "zxcv/3", suffix: 11},
+	}
+
+	for _, test := range tests {
+		suf := fmt.Sprintf("%d", test.suffix)
+
+		action := names.NewActionTag(test.prefix + names.ActionMarker + suf)
+		c.Assert(action.Prefix(), gc.Equals, test.prefix)
+		c.Assert(action.Sequence(), gc.Equals, test.suffix)
+
+		result := names.NewActionResultTag(test.prefix + names.ActionResultMarker + suf)
+		c.Assert(result.Prefix(), gc.Equals, test.prefix)
+		c.Assert(result.Sequence(), gc.Equals, test.suffix)
+
+		c.Assert(action.PrefixTag(), gc.Not(gc.IsNil))
+		c.Assert(action.PrefixTag(), gc.DeepEquals, result.PrefixTag())
+	}
+}

--- a/equality_test.go
+++ b/equality_test.go
@@ -19,8 +19,10 @@ var tagEqualityTests = []struct {
 	{NewEnvironTag("local"), EnvironTag{uuid: "local"}},
 	{NewUserTag("admin"), UserTag{name: "admin"}},
 	{NewNetworkTag("eth0"), NetworkTag{name: "eth0"}},
-	{NewActionTag("foo" + actionMarker + "321"), ActionTag{id: "foo" + actionMarker + "321"}},
-	{NewActionTag("foo/0" + actionMarker + "321"), ActionTag{id: "foo/0" + actionMarker + "321"}},
+	{NewActionTag("foo" + actionMarker + "321"), makeActionTag("foo", "321")},
+	{NewActionTag("foo/0" + actionMarker + "321"), makeActionTag("foo/0", "321")},
+	{NewActionResultTag("foo" + actionResultMarker + "321"), makeActionResultTag("foo", "321")},
+	{NewActionResultTag("foo/0" + actionResultMarker + "321"), makeActionResultTag("foo/0", "321")},
 }
 
 type equalitySuite struct{}
@@ -31,4 +33,16 @@ func (s *equalitySuite) TestTagEquality(c *gc.C) {
 	for _, tt := range tagEqualityTests {
 		c.Check(tt.want, gc.Equals, tt.expected)
 	}
+}
+
+func makeActionTag(prefix, suffix string) ActionTag {
+	id := prefix + ActionMarker + suffix
+	return ActionTag{idPrefixer: makePrefixer(id, ActionTagKind, ActionMarker)}
+}
+func makeActionResultTag(prefix, suffix string) ActionResultTag {
+	id := prefix + ActionResultMarker + suffix
+	return ActionResultTag{idPrefixer: makePrefixer(id, ActionResultTagKind, ActionResultMarker)}
+}
+func makePrefixer(id, kind, marker string) idPrefixer {
+	return idPrefixer{id: id, kind: kind, marker: marker}
 }


### PR DESCRIPTION
To leverage common implementation details.

We need much of the same functionality (Prefix, Sequence, PrefixTag) from ActionResultTags as ActionTags
