### PR TITLE
Export name field of ServiceTag for API

### DIFF
--- a/equality_test.go
+++ b/equality_test.go
@@ -14,7 +14,7 @@ var tagEqualityTests = []struct {
 	{NewMachineTag("0"), MachineTag{id: "0"}},
 	{NewMachineTag("10/lxc/1"), MachineTag{id: "10-lxc-1"}},
 	{NewUnitTag("mysql/1"), UnitTag{name: "mysql-1"}},
-	{NewServiceTag("ceph"), ServiceTag{name: "ceph"}},
+	{NewServiceTag("ceph"), ServiceTag{Name: "ceph"}},
 	{NewRelationTag("wordpress:haproxy"), RelationTag{key: "wordpress.haproxy"}},
 	{NewEnvironTag("local"), EnvironTag{uuid: "local"}},
 	{NewUserTag("admin"), UserTag{name: "admin"}},

--- a/service.go
+++ b/service.go
@@ -22,16 +22,16 @@ func IsValidService(name string) bool {
 }
 
 type ServiceTag struct {
-	name string
+	Name string
 }
 
 func (t ServiceTag) String() string { return t.Kind() + "-" + t.Id() }
 func (t ServiceTag) Kind() string   { return ServiceTagKind }
-func (t ServiceTag) Id() string     { return t.name }
+func (t ServiceTag) Id() string     { return t.Name }
 
 // NewServiceTag returns the tag for the service with the given name.
 func NewServiceTag(serviceName string) ServiceTag {
-	return ServiceTag{name: serviceName}
+	return ServiceTag{Name: serviceName}
 }
 
 // ParseServiceTag parses a service tag string.


### PR DESCRIPTION
This change is necessary in order to use names.ServiceTag over the wire.
cf. commit IDs a96b793, ed7883d
