### PR TITLE
Introduce DiskTag

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -1,0 +1,56 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const DiskTagKind = "disk"
+
+var validDisk = regexp.MustCompile("^" + NumberSnippet + "$")
+
+type DiskTag struct {
+	name string
+}
+
+func (t DiskTag) String() string { return t.Kind() + "-" + t.name }
+func (t DiskTag) Kind() string   { return DiskTagKind }
+func (t DiskTag) Id() string     { return t.name }
+
+// NewDiskTag returns the tag for the disk with the given name.
+// It will panic if the given disk name is not valid.
+func NewDiskTag(diskName string) DiskTag {
+	tag, ok := tagFromDiskName(diskName)
+	if !ok {
+		panic(fmt.Sprintf("%q is not a valid disk name", diskName))
+	}
+	return tag
+}
+
+// ParseDiskTag parses a disk tag string.
+func ParseDiskTag(diskTag string) (DiskTag, error) {
+	tag, err := ParseTag(diskTag)
+	if err != nil {
+		return DiskTag{}, err
+	}
+	dt, ok := tag.(DiskTag)
+	if !ok {
+		return DiskTag{}, invalidTagError(diskTag, DiskTagKind)
+	}
+	return dt, nil
+}
+
+// IsValidDisk returns whether name is a valid disk name.
+func IsValidDisk(name string) bool {
+	return validDisk.MatchString(name)
+}
+
+func tagFromDiskName(diskName string) (DiskTag, bool) {
+	if !IsValidDisk(diskName) {
+		return DiskTag{}, false
+	}
+	return DiskTag{diskName}, true
+}

--- a/disk_test.go
+++ b/disk_test.go
@@ -1,0 +1,61 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	"fmt"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/names"
+)
+
+type diskSuite struct{}
+
+var _ = gc.Suite(&diskSuite{})
+
+func (s *diskSuite) TestDiskTag(c *gc.C) {
+	c.Assert(names.NewDiskTag("1").String(), gc.Equals, "disk-1")
+}
+
+func (s *diskSuite) TestDiskNameValidity(c *gc.C) {
+	assertDiskNameValid(c, "0")
+	assertDiskNameValid(c, "1000")
+	assertDiskNameInvalid(c, "-1")
+	assertDiskNameInvalid(c, "")
+	assertDiskNameInvalid(c, "one")
+	assertDiskNameInvalid(c, "#")
+}
+
+func (s *diskSuite) TestParseDiskTag(c *gc.C) {
+	assertParseDiskTag(c, "disk-0", names.NewDiskTag("0"))
+	assertParseDiskTag(c, "disk-88", names.NewDiskTag("88"))
+	assertParseDiskTagInvalid(c, "", names.InvalidTagError("", ""))
+	assertParseDiskTagInvalid(c, "one", names.InvalidTagError("one", ""))
+	assertParseDiskTagInvalid(c, "disk-", names.InvalidTagError("disk-", names.DiskTagKind))
+	assertParseDiskTagInvalid(c, "machine-0", names.InvalidTagError("machine-0", names.DiskTagKind))
+}
+
+func assertDiskNameValid(c *gc.C, name string) {
+	c.Assert(names.IsValidDisk(name), gc.Equals, true)
+	names.NewDiskTag(name)
+}
+
+func assertDiskNameInvalid(c *gc.C, name string) {
+	c.Assert(names.IsValidDisk(name), gc.Equals, false)
+	testDiskTag := func() { names.NewDiskTag(name) }
+	expect := fmt.Sprintf("%q is not a valid disk name", name)
+	c.Assert(testDiskTag, gc.PanicMatches, expect)
+}
+
+func assertParseDiskTag(c *gc.C, tag string, expect names.DiskTag) {
+	t, err := names.ParseDiskTag(tag)
+	c.Assert(err, gc.IsNil)
+	c.Assert(t, gc.Equals, expect)
+}
+
+func assertParseDiskTagInvalid(c *gc.C, tag string, expect error) {
+	_, err := names.ParseDiskTag(tag)
+	c.Assert(err, gc.ErrorMatches, expect.Error())
+}

--- a/tag.go
+++ b/tag.go
@@ -36,7 +36,7 @@ func TagKind(tag string) (string, error) {
 
 func validKinds(kind string) bool {
 	switch kind {
-	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind, RelationTagKind, NetworkTagKind, ActionTagKind:
+	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind, RelationTagKind, NetworkTagKind, ActionTagKind, DiskTagKind:
 		return true
 	}
 	return false
@@ -100,6 +100,11 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewActionTag(id), nil
+	case DiskTagKind:
+		if !IsValidDisk(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewDiskTag(id), nil
 	default:
 		return nil, invalidTagError(tag, "")
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -31,6 +31,7 @@ var tagKindTests = []struct {
 	{tag: "network-42", kind: names.NetworkTagKind},
 	{tag: "ab01cd23-0123-4edc-9a8b-fedcba987654", err: `"ab01cd23-0123-4edc-9a8b-fedcba987654" is not a valid tag`},
 	{tag: "action-ab01cd23-0123-4edc-9a8b-fedcba987654", kind: names.ActionTagKind},
+	{tag: "disk-0", kind: names.DiskTagKind},
 }
 
 func (*tagSuite) TestTagKind(c *gc.C) {
@@ -154,6 +155,11 @@ var parseTagTests = []struct {
 	expectType: names.ActionTag{},
 	resultId:   "abedaf33-3212-4fde-aeca-87356432deca",
 }, {
+	tag:        "disk-2",
+	expectKind: names.DiskTagKind,
+	expectType: names.DiskTag{},
+	resultId:   "2",
+}, {
 	tag:       "foo",
 	resultErr: `"foo" is not a valid tag`,
 }}
@@ -167,6 +173,7 @@ var makeTag = map[string]func(string) names.Tag{
 	names.UserTagKind:     func(tag string) names.Tag { return names.NewUserTag(tag) },
 	names.NetworkTagKind:  func(tag string) names.Tag { return names.NewNetworkTag(tag) },
 	names.ActionTagKind:   func(tag string) names.Tag { return names.NewActionTag(tag) },
+	names.DiskTagKind:     func(tag string) names.Tag { return names.NewDiskTag(tag) },
 }
 
 func (*tagSuite) TestParseTag(c *gc.C) {


### PR DESCRIPTION
DiskTag will be used to uniquely identify disks (block devices),
either attached or unattached. DiskTag's format is disk-<seq>.
