### PR TITLE
unitservice return err, not panic

### DIFF
--- a/unit.go
+++ b/unit.go
@@ -50,13 +50,13 @@ func IsValidUnit(name string) bool {
 }
 
 // UnitService returns the name of the service that the unit is
-// associated with. It panics if unitName is not a valid unit name.
-func UnitService(unitName string) string {
+// associated with. It returns an error if unitName is not a valid unit name.
+func UnitService(unitName string) (string, error) {
 	s := validUnit.FindStringSubmatch(unitName)
 	if s == nil {
-		panic(fmt.Sprintf("%q is not a valid unit name", unitName))
+		return "", fmt.Errorf("%q is not a valid unit name", unitName)
 	}
-	return s[1]
+	return s[1], nil
 }
 
 func tagFromUnitName(unitName string) (UnitTag, bool) {

--- a/unit_test.go
+++ b/unit_test.go
@@ -59,10 +59,12 @@ func (s *serviceSuite) TestUnitService(c *gc.C) {
 		c.Logf("test %d: %q", i, test.pattern)
 		if !test.valid {
 			expect := fmt.Sprintf("%q is not a valid unit name", test.pattern)
-			testFunc := func() { names.UnitService(test.pattern) }
-			c.Assert(testFunc, gc.PanicMatches, expect)
+			_, err := names.UnitService(test.pattern)
+			c.Assert(err, gc.ErrorMatches, expect)
 		} else {
-			c.Assert(names.UnitService(test.pattern), gc.Equals, test.service)
+			result, err := names.UnitService(test.pattern)
+			c.Assert(err, gc.IsNil)
+			c.Assert(result, gc.Equals, test.service)
 		}
 	}
 }


### PR DESCRIPTION
a call to UnitService will currently panic if the unitname provided is invalid. This is simple to avoid by checking IsValidUnit before the call. However this causes problems if the value could be changed in between the calls. And practically speaking there are a number of places where UnitService is called and "IsValidUnit" isn't called.

Regardless of the above I still feel it's better for the library to return an error rather than panicing. It does mean an api change, but I think it's worth it.