### PR TITLE
names: add StorageTag

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,75 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	StorageTagKind = "storage"
+
+	// StorageNameSnippet is the regular expression that describes valid
+	// storage names (without the storage instance sequence number).
+	StorageNameSnippet = "(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)"
+)
+
+var validStorage = regexp.MustCompile("^(" + StorageNameSnippet + ")/" + NumberSnippet + "$")
+
+type StorageTag struct {
+	id string
+}
+
+func (t StorageTag) String() string { return t.Kind() + "-" + t.id }
+func (t StorageTag) Kind() string   { return StorageTagKind }
+func (t StorageTag) Id() string     { return storageTagSuffixToId(t.id) }
+
+// NewStorageTag returns the tag for the storage instance with the given ID.
+// It will panic if the given string is not a valid storage instance Id.
+func NewStorageTag(id string) StorageTag {
+	tag, ok := tagFromStorageId(id)
+	if !ok {
+		panic(fmt.Sprintf("%q is not a valid storage instance ID", id))
+	}
+	return tag
+}
+
+// ParseStorageTag parses a storage tag string.
+func ParseStorageTag(s string) (StorageTag, error) {
+	tag, err := ParseTag(s)
+	if err != nil {
+		return StorageTag{}, err
+	}
+	st, ok := tag.(StorageTag)
+	if !ok {
+		return StorageTag{}, invalidTagError(s, StorageTagKind)
+	}
+	return st, nil
+}
+
+// IsValidStorage returns whether id is a valid storage instance ID.
+func IsValidStorage(id string) bool {
+	return validStorage.MatchString(id)
+}
+
+func tagFromStorageId(id string) (StorageTag, bool) {
+	// replace only the last "/" with "-".
+	i := strings.LastIndex(id, "/")
+	if i <= 0 || !IsValidStorage(id) {
+		return StorageTag{}, false
+	}
+	id = id[:i] + "-" + id[i+1:]
+	return StorageTag{id}, true
+}
+
+func storageTagSuffixToId(s string) string {
+	// Replace only the last "-" with "/", as it is valid for storage
+	// names to contain hyphens.
+	if i := strings.LastIndex(s, "-"); i > 0 {
+		s = s[:i] + "/" + s[i+1:]
+	}
+	return s
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,62 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	"fmt"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/names"
+)
+
+type storageSuite struct{}
+
+var _ = gc.Suite(&storageSuite{})
+
+func (s *storageSuite) TestStorageTag(c *gc.C) {
+	c.Assert(names.NewStorageTag("store/1").String(), gc.Equals, "storage-store-1")
+}
+
+func (s *storageSuite) TestStorageNameValidity(c *gc.C) {
+	assertStorageNameValid(c, "store/0")
+	assertStorageNameValid(c, "store/1000")
+	assertStorageNameInvalid(c, "store/-1")
+	assertStorageNameInvalid(c, "store-1")
+	assertStorageNameInvalid(c, "")
+	assertStorageNameInvalid(c, "store")
+	assertStorageNameInvalid(c, "store/#")
+}
+
+func (s *storageSuite) TestParseStorageTag(c *gc.C) {
+	assertParseStorageTag(c, "storage-store-0", names.NewStorageTag("store/0"))
+	assertParseStorageTag(c, "storage-store-88", names.NewStorageTag("store/88"))
+	assertParseStorageTagInvalid(c, "", names.InvalidTagError("", ""))
+	assertParseStorageTagInvalid(c, "one", names.InvalidTagError("one", ""))
+	assertParseStorageTagInvalid(c, "storage-", names.InvalidTagError("storage-", names.StorageTagKind))
+	assertParseStorageTagInvalid(c, "machine-0", names.InvalidTagError("machine-0", names.StorageTagKind))
+}
+
+func assertStorageNameValid(c *gc.C, name string) {
+	c.Assert(names.IsValidStorage(name), gc.Equals, true)
+	names.NewStorageTag(name)
+}
+
+func assertStorageNameInvalid(c *gc.C, name string) {
+	c.Assert(names.IsValidStorage(name), gc.Equals, false)
+	testStorageTag := func() { names.NewStorageTag(name) }
+	expect := fmt.Sprintf("%q is not a valid storage instance ID", name)
+	c.Assert(testStorageTag, gc.PanicMatches, expect)
+}
+
+func assertParseStorageTag(c *gc.C, tag string, expect names.StorageTag) {
+	t, err := names.ParseStorageTag(tag)
+	c.Assert(err, gc.IsNil)
+	c.Assert(t, gc.Equals, expect)
+}
+
+func assertParseStorageTagInvalid(c *gc.C, tag string, expect error) {
+	_, err := names.ParseStorageTag(tag)
+	c.Assert(err, gc.ErrorMatches, expect.Error())
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -20,8 +20,8 @@ func (s *storageSuite) TestStorageTag(c *gc.C) {
 }
 
 func (s *storageSuite) TestStorageNameValidity(c *gc.C) {
-	assertStorageNameValid(c, "store/0")
-	assertStorageNameValid(c, "store/1000")
+	assertStorageNameValid(c, "shared-fs/0")
+	assertStorageNameValid(c, "db-dir/1000")
 	assertStorageNameInvalid(c, "store/-1")
 	assertStorageNameInvalid(c, "store-1")
 	assertStorageNameInvalid(c, "")
@@ -30,7 +30,7 @@ func (s *storageSuite) TestStorageNameValidity(c *gc.C) {
 }
 
 func (s *storageSuite) TestParseStorageTag(c *gc.C) {
-	assertParseStorageTag(c, "storage-store-0", names.NewStorageTag("store/0"))
+	assertParseStorageTag(c, "storage-shared-fs-0", names.NewStorageTag("shared-fs/0"))
 	assertParseStorageTag(c, "storage-store-88", names.NewStorageTag("store/88"))
 	assertParseStorageTagInvalid(c, "", names.InvalidTagError("", ""))
 	assertParseStorageTagInvalid(c, "one", names.InvalidTagError("one", ""))

--- a/tag.go
+++ b/tag.go
@@ -36,7 +36,7 @@ func TagKind(tag string) (string, error) {
 
 func validKinds(kind string) bool {
 	switch kind {
-	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind, RelationTagKind, NetworkTagKind, ActionTagKind, DiskTagKind, CharmTagKind:
+	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind, RelationTagKind, NetworkTagKind, ActionTagKind, DiskTagKind, CharmTagKind, StorageTagKind:
 		return true
 	}
 	return false
@@ -110,6 +110,12 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewCharmTag(id), nil
+	case StorageTagKind:
+		id = storageTagSuffixToId(id)
+		if !IsValidStorage(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewStorageTag(id), nil
 	default:
 		return nil, invalidTagError(tag, "")
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -32,6 +32,7 @@ var tagKindTests = []struct {
 	{tag: "ab01cd23-0123-4edc-9a8b-fedcba987654", err: `"ab01cd23-0123-4edc-9a8b-fedcba987654" is not a valid tag`},
 	{tag: "action-ab01cd23-0123-4edc-9a8b-fedcba987654", kind: names.ActionTagKind},
 	{tag: "disk-0", kind: names.DiskTagKind},
+	{tag: "storage-data-0", kind: names.StorageTagKind},
 }
 
 func (*tagSuite) TestTagKind(c *gc.C) {
@@ -160,6 +161,11 @@ var parseTagTests = []struct {
 	expectType: names.DiskTag{},
 	resultId:   "2",
 }, {
+	tag:        "storage-block-storage-0",
+	expectKind: names.StorageTagKind,
+	expectType: names.StorageTag{},
+	resultId:   "block-storage/0",
+}, {
 	tag:       "foo",
 	resultErr: `"foo" is not a valid tag`,
 }}
@@ -174,6 +180,7 @@ var makeTag = map[string]func(string) names.Tag{
 	names.NetworkTagKind:  func(tag string) names.Tag { return names.NewNetworkTag(tag) },
 	names.ActionTagKind:   func(tag string) names.Tag { return names.NewActionTag(tag) },
 	names.DiskTagKind:     func(tag string) names.Tag { return names.NewDiskTag(tag) },
+	names.StorageTagKind:  func(tag string) names.Tag { return names.NewStorageTag(tag) },
 }
 
 func (*tagSuite) TestParseTag(c *gc.C) {


### PR DESCRIPTION
A new kind of tag is added for referring to storage instances;
these are instances of charm storage. The format is "storage/N",
where "storage" is the name defined in charm storage metadata
and "N" is a unique sequence number.