### PR TITLE
Add ReadableString to generate a human-readable string from a tag

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -127,3 +127,14 @@ func invalidTagError(tag, kind string) error {
 	}
 	return fmt.Errorf("%q is not a valid tag", tag)
 }
+
+// ReadableString returns a human-readable string from the tag passed in.
+// It currently supports unit and machine tags. Support for additional types
+// can be added in as needed.
+func ReadableString(tag Tag) string {
+	if tag == nil {
+		return ""
+	}
+
+	return tag.Kind() + " " + tag.Id()
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -226,3 +226,25 @@ func (*tagSuite) TestParseTag(c *gc.C) {
 		}
 	}
 }
+
+func (*tagSuite) TestReadableString(c *gc.C) {
+	var readableStringTests = []struct {
+		tag    names.Tag
+		result string
+	}{{
+		tag:    nil,
+		result: "",
+	}, {
+		tag:    names.NewMachineTag("0"),
+		result: "machine 0",
+	}, {
+		tag:    names.NewUnitTag("wordpress/2"),
+		result: "unit wordpress/2",
+	}}
+
+	for i, test := range readableStringTests {
+		c.Logf("test %d: expected result %q", i, test.result)
+		resultStr := names.ReadableString(test.tag)
+		c.Assert(resultStr, gc.Equals, test.result)
+	}
+}


### PR DESCRIPTION
ReadableString will return a string that is appropriate for displaying
in the UI.  This is in response to review comments for review request
814: http://reviews.vapour.ws/r/814/