### PR TITLE
Add FilesystemTag

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -1,0 +1,69 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	FilesystemTagKind = "filesystem"
+	filenameSnippet   = "[\\w. ][\\w\\-. ]*"
+)
+
+var validFilesystem = regexp.MustCompile("^" + filenameSnippet + "$")
+
+type FilesystemTag struct {
+	name string
+}
+
+func (t FilesystemTag) String() string { return t.Kind() + "-" + t.name }
+func (t FilesystemTag) Kind() string   { return FilesystemTagKind }
+func (t FilesystemTag) Id() string     { return t.name }
+
+// NewFilesystemTag returns the tag for the filesystem with the given name.
+// It will panic if the given filesystem name is not valid.
+func NewFilesystemTag(filesystemName string) FilesystemTag {
+	tag, ok := tagFromFilesystemName(filesystemName)
+	if !ok {
+		panic(fmt.Sprintf("%q is not a valid filesystem name", filesystemName))
+	}
+	return tag
+}
+
+// ParseFilesystemTag parses a filesystem tag string.
+func ParseFilesystemTag(filesystemTag string) (FilesystemTag, error) {
+	tag, err := ParseTag(filesystemTag)
+	if err != nil {
+		return FilesystemTag{}, err
+	}
+	fstag, ok := tag.(FilesystemTag)
+	if !ok {
+		return FilesystemTag{}, invalidTagError(filesystemTag, FilesystemTagKind)
+	}
+	return fstag, nil
+}
+
+// IsValidFilesystem returns whether name is a valid filesystem name.
+func IsValidFilesystem(name string) bool {
+	return validFilesystem.MatchString(name)
+}
+
+func tagFromFilesystemName(filesystemName string) (FilesystemTag, bool) {
+	if !IsValidFilesystem(filesystemName) {
+		return FilesystemTag{}, false
+	}
+	return FilesystemTag{filesystemName}, true
+}
+
+func filesystemTagSuffixToId(s string) string {
+	// Replace only the last "-" with "/", as it is valid for filesystem
+	// names to contain hyphens.
+	if i := strings.LastIndex(s, "-"); i > 0 {
+		s = s[:i] + "/" + s[i+1:]
+	}
+	return s
+}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -16,35 +16,56 @@ type filesystemSuite struct{}
 var _ = gc.Suite(&filesystemSuite{})
 
 func (s *filesystemSuite) TestFilesystemTag(c *gc.C) {
-	c.Assert(names.NewFilesystemTag("abc").String(), gc.Equals, "filesystem-abc")
+	c.Assert(names.NewFilesystemTag("1").String(), gc.Equals, "filesystem-1")
 }
 
-func (s *filesystemSuite) TestFilesystemNameValidity(c *gc.C) {
-	assertFilesystemNameValid(c, "abc")
-	assertFilesystemNameValid(c, "abc-def.123")
-	assertFilesystemNameInvalid(c, "-1")
-	assertFilesystemNameInvalid(c, "")
-	assertFilesystemNameInvalid(c, "#")
+func (s *filesystemSuite) TestFilesystemIdValidity(c *gc.C) {
+	assertFilesystemIdValid(c, "0")
+	assertFilesystemIdValid(c, "0/lxc/0/0")
+	assertFilesystemIdValid(c, "1000")
+	assertFilesystemIdInvalid(c, "-1")
+	assertFilesystemIdInvalid(c, "")
+	assertFilesystemIdInvalid(c, "one")
+	assertFilesystemIdInvalid(c, "#")
+	assertFilesystemIdInvalid(c, "0/0/0") // 0/0 is not a valid machine ID
 }
 
 func (s *filesystemSuite) TestParseFilesystemTag(c *gc.C) {
-	assertParseFilesystemTag(c, "filesystem-abc", names.NewFilesystemTag("abc"))
+	assertParseFilesystemTag(c, "filesystem-0", names.NewFilesystemTag("0"))
 	assertParseFilesystemTag(c, "filesystem-88", names.NewFilesystemTag("88"))
+	assertParseFilesystemTag(c, "filesystem-0-lxc-0-88", names.NewFilesystemTag("0/lxc/0/88"))
 	assertParseFilesystemTagInvalid(c, "", names.InvalidTagError("", ""))
 	assertParseFilesystemTagInvalid(c, "one", names.InvalidTagError("one", ""))
 	assertParseFilesystemTagInvalid(c, "filesystem-", names.InvalidTagError("filesystem-", names.FilesystemTagKind))
 	assertParseFilesystemTagInvalid(c, "machine-0", names.InvalidTagError("machine-0", names.FilesystemTagKind))
 }
 
-func assertFilesystemNameValid(c *gc.C, name string) {
+func (s *filesystemSuite) TestFilesystemMachine(c *gc.C) {
+	assertFilesystemMachine(c, "0/0", names.NewMachineTag("0"))
+	assertFilesystemMachine(c, "0/lxc/0/0", names.NewMachineTag("0/lxc/0"))
+	assertFilesystemNoMachine(c, "0")
+}
+
+func assertFilesystemMachine(c *gc.C, id string, expect names.MachineTag) {
+	t, ok := names.FilesystemMachine(names.NewFilesystemTag(id))
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(t, gc.Equals, expect)
+}
+
+func assertFilesystemNoMachine(c *gc.C, id string) {
+	_, ok := names.FilesystemMachine(names.NewFilesystemTag(id))
+	c.Assert(ok, gc.Equals, false)
+}
+
+func assertFilesystemIdValid(c *gc.C, name string) {
 	c.Assert(names.IsValidFilesystem(name), gc.Equals, true)
 	names.NewFilesystemTag(name)
 }
 
-func assertFilesystemNameInvalid(c *gc.C, name string) {
+func assertFilesystemIdInvalid(c *gc.C, name string) {
 	c.Assert(names.IsValidFilesystem(name), gc.Equals, false)
 	testFilesystemTag := func() { names.NewFilesystemTag(name) }
-	expect := fmt.Sprintf("%q is not a valid filesystem name", name)
+	expect := fmt.Sprintf("%q is not a valid filesystem id", name)
 	c.Assert(testFilesystemTag, gc.PanicMatches, expect)
 }
 

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -1,0 +1,60 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	"fmt"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/names"
+)
+
+type filesystemSuite struct{}
+
+var _ = gc.Suite(&filesystemSuite{})
+
+func (s *filesystemSuite) TestFilesystemTag(c *gc.C) {
+	c.Assert(names.NewFilesystemTag("abc").String(), gc.Equals, "filesystem-abc")
+}
+
+func (s *filesystemSuite) TestFilesystemNameValidity(c *gc.C) {
+	assertFilesystemNameValid(c, "abc")
+	assertFilesystemNameValid(c, "abc-def.123")
+	assertFilesystemNameInvalid(c, "-1")
+	assertFilesystemNameInvalid(c, "")
+	assertFilesystemNameInvalid(c, "#")
+}
+
+func (s *filesystemSuite) TestParseFilesystemTag(c *gc.C) {
+	assertParseFilesystemTag(c, "filesystem-abc", names.NewFilesystemTag("abc"))
+	assertParseFilesystemTag(c, "filesystem-88", names.NewFilesystemTag("88"))
+	assertParseFilesystemTagInvalid(c, "", names.InvalidTagError("", ""))
+	assertParseFilesystemTagInvalid(c, "one", names.InvalidTagError("one", ""))
+	assertParseFilesystemTagInvalid(c, "filesystem-", names.InvalidTagError("filesystem-", names.FilesystemTagKind))
+	assertParseFilesystemTagInvalid(c, "machine-0", names.InvalidTagError("machine-0", names.FilesystemTagKind))
+}
+
+func assertFilesystemNameValid(c *gc.C, name string) {
+	c.Assert(names.IsValidFilesystem(name), gc.Equals, true)
+	names.NewFilesystemTag(name)
+}
+
+func assertFilesystemNameInvalid(c *gc.C, name string) {
+	c.Assert(names.IsValidFilesystem(name), gc.Equals, false)
+	testFilesystemTag := func() { names.NewFilesystemTag(name) }
+	expect := fmt.Sprintf("%q is not a valid filesystem name", name)
+	c.Assert(testFilesystemTag, gc.PanicMatches, expect)
+}
+
+func assertParseFilesystemTag(c *gc.C, tag string, expect names.FilesystemTag) {
+	t, err := names.ParseFilesystemTag(tag)
+	c.Assert(err, gc.IsNil)
+	c.Assert(t, gc.Equals, expect)
+}
+
+func assertParseFilesystemTagInvalid(c *gc.C, tag string, expect error) {
+	_, err := names.ParseFilesystemTag(tag)
+	c.Assert(err, gc.ErrorMatches, expect.Error())
+}

--- a/tag.go
+++ b/tag.go
@@ -36,7 +36,8 @@ func TagKind(tag string) (string, error) {
 
 func validKinds(kind string) bool {
 	switch kind {
-	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind, RelationTagKind, NetworkTagKind, ActionTagKind, VolumeTagKind, CharmTagKind, StorageTagKind:
+	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind, RelationTagKind, NetworkTagKind,
+		ActionTagKind, VolumeTagKind, CharmTagKind, StorageTagKind, FilesystemTagKind:
 		return true
 	}
 	return false
@@ -117,6 +118,12 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewStorageTag(id), nil
+	case FilesystemTagKind:
+		id = filesystemTagSuffixToId(id)
+		if !IsValidFilesystem(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewFilesystemTag(id), nil
 	default:
 		return nil, invalidTagError(tag, "")
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -33,6 +33,7 @@ var tagKindTests = []struct {
 	{tag: "action-ab01cd23-0123-4edc-9a8b-fedcba987654", kind: names.ActionTagKind},
 	{tag: "volume-0", kind: names.VolumeTagKind},
 	{tag: "storage-data-0", kind: names.StorageTagKind},
+	{tag: "filesystem-0", kind: names.FilesystemTagKind},
 }
 
 func (*tagSuite) TestTagKind(c *gc.C) {
@@ -161,6 +162,11 @@ var parseTagTests = []struct {
 	expectType: names.VolumeTag{},
 	resultId:   "2",
 }, {
+	tag:        "filesystem-3",
+	expectKind: names.FilesystemTagKind,
+	expectType: names.FilesystemTag{},
+	resultId:   "3",
+}, {
 	tag:        "storage-block-storage-0",
 	expectKind: names.StorageTagKind,
 	expectType: names.StorageTag{},
@@ -171,16 +177,17 @@ var parseTagTests = []struct {
 }}
 
 var makeTag = map[string]func(string) names.Tag{
-	names.MachineTagKind:  func(tag string) names.Tag { return names.NewMachineTag(tag) },
-	names.UnitTagKind:     func(tag string) names.Tag { return names.NewUnitTag(tag) },
-	names.ServiceTagKind:  func(tag string) names.Tag { return names.NewServiceTag(tag) },
-	names.RelationTagKind: func(tag string) names.Tag { return names.NewRelationTag(tag) },
-	names.EnvironTagKind:  func(tag string) names.Tag { return names.NewEnvironTag(tag) },
-	names.UserTagKind:     func(tag string) names.Tag { return names.NewUserTag(tag) },
-	names.NetworkTagKind:  func(tag string) names.Tag { return names.NewNetworkTag(tag) },
-	names.ActionTagKind:   func(tag string) names.Tag { return names.NewActionTag(tag) },
-	names.VolumeTagKind:   func(tag string) names.Tag { return names.NewVolumeTag(tag) },
-	names.StorageTagKind:  func(tag string) names.Tag { return names.NewStorageTag(tag) },
+	names.MachineTagKind:    func(tag string) names.Tag { return names.NewMachineTag(tag) },
+	names.UnitTagKind:       func(tag string) names.Tag { return names.NewUnitTag(tag) },
+	names.ServiceTagKind:    func(tag string) names.Tag { return names.NewServiceTag(tag) },
+	names.RelationTagKind:   func(tag string) names.Tag { return names.NewRelationTag(tag) },
+	names.EnvironTagKind:    func(tag string) names.Tag { return names.NewEnvironTag(tag) },
+	names.UserTagKind:       func(tag string) names.Tag { return names.NewUserTag(tag) },
+	names.NetworkTagKind:    func(tag string) names.Tag { return names.NewNetworkTag(tag) },
+	names.ActionTagKind:     func(tag string) names.Tag { return names.NewActionTag(tag) },
+	names.VolumeTagKind:     func(tag string) names.Tag { return names.NewVolumeTag(tag) },
+	names.FilesystemTagKind: func(tag string) names.Tag { return names.NewFilesystemTag(tag) },
+	names.StorageTagKind:    func(tag string) names.Tag { return names.NewStorageTag(tag) },
 }
 
 func (*tagSuite) TestParseTag(c *gc.C) {


### PR DESCRIPTION
Add support for a Filesystem tag.
For maximum flexibility, the tag id is allowed to be any valid directory name. This is because in Juju, when no location is specified when creating a fs mount, the mount point is created from the tag id.