### PR TITLE
Fixes lp:1446608 - accept [a-zA-Z0-9_-]+ in network names.

### DIFF
--- a/network.go
+++ b/network.go
@@ -11,7 +11,7 @@ import (
 const NetworkTagKind = "network"
 
 const (
-	NetworkSnippet = "(?:[a-z0-9]+(?:-[a-z0-9]+)*)"
+	NetworkSnippet = "(?:[a-zA-Z0-9_-]+)"
 )
 
 var validNetwork = regexp.MustCompile("^" + NetworkSnippet + "$")

--- a/network_test.go
+++ b/network_test.go
@@ -22,18 +22,19 @@ var networkNameTests = []struct {
 }{
 	{pattern: "", valid: false},
 	{pattern: "eth0", valid: true},
-	{pattern: "-my-net-", valid: false},
+	{pattern: "-my-net-", valid: true},
 	{pattern: "42", valid: true},
 	{pattern: "%not", valid: false},
 	{pattern: "$PATH", valid: false},
 	{pattern: "but-this-works", valid: true},
-	{pattern: "----", valid: false},
-	{pattern: "oh--no", valid: false},
+	{pattern: "----", valid: true},
+	{pattern: "oh--no", valid: true},
 	{pattern: "777", valid: true},
-	{pattern: "is-it-", valid: false},
-	{pattern: "also_not", valid: false},
-	{pattern: "a--", valid: false},
+	{pattern: "is-it-", valid: true},
+	{pattern: "also_not", valid: true},
+	{pattern: "a--", valid: true},
 	{pattern: "foo-2", valid: true},
+	{pattern: "MAAS_n3t-w0rK-", valid: true},
 }
 
 func (s *networkSuite) TestNetworkNames(c *gc.C) {


### PR DESCRIPTION
Changes the accepted format for juju network names and tags to match the
charset accepted by MAAS: [\w_]+, taking into account in python, the
regexp package translates "\w" to "[a-zA-Z0-9-]".

See http://pad.lv/1446608.

(Review request: http://reviews.vapour.ws/r/1501/)