### PR TITLE
Added subnet tag kind

### DIFF
--- a/subnet.go
+++ b/subnet.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"fmt"
+	"net"
+)
+
+const SubnetTagKind = "subnet"
+
+// IsValidSubnet returns whether cidr is a valid subnet CIDR.
+func IsValidSubnet(cidr string) bool {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err == nil && ipNet.String() == cidr {
+		return true
+	}
+	return false
+}
+
+type SubnetTag struct {
+	cidr string
+}
+
+func (t SubnetTag) String() string { return t.Kind() + "-" + t.cidr }
+func (t SubnetTag) Kind() string   { return SubnetTagKind }
+func (t SubnetTag) Id() string     { return t.cidr }
+
+// NewSubnetTag returns the tag for subnet with the given CIDR.
+func NewSubnetTag(cidr string) SubnetTag {
+	if !IsValidSubnet(cidr) {
+		panic(fmt.Sprintf("%s is not a valid subnet CIDR", cidr))
+	}
+	return SubnetTag{cidr: cidr}
+}
+
+// ParseSubnetTag parses a subnet tag string.
+func ParseSubnetTag(subnetTag string) (SubnetTag, error) {
+	tag, err := ParseTag(subnetTag)
+	if err != nil {
+		return SubnetTag{}, err
+	}
+	subt, ok := tag.(SubnetTag)
+	if !ok {
+		return SubnetTag{}, invalidTagError(subnetTag, SubnetTagKind)
+	}
+	return subt, nil
+}

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/names"
+)
+
+type subnetSuite struct{}
+
+var _ = gc.Suite(&subnetSuite{})
+
+func (s *subnetSuite) TestNewSubnetTag(c *gc.C) {
+	cidr := "10.20.0.0/16"
+	tag := names.NewSubnetTag(cidr)
+	parsed, err := names.ParseSubnetTag(tag.String())
+	c.Assert(err, gc.IsNil)
+	c.Assert(parsed.Kind(), gc.Equals, names.SubnetTagKind)
+	c.Assert(parsed.Id(), gc.Equals, cidr)
+	c.Assert(parsed.String(), gc.Equals, names.SubnetTagKind+"-"+cidr)
+
+	f := func() {
+		tag = names.NewSubnetTag("foo")
+	}
+	c.Assert(f, gc.PanicMatches, "foo is not a valid subnet CIDR")
+}
+
+var parseSubnetTagTests = []struct {
+	tag      string
+	expected names.Tag
+	err      error
+}{{
+	tag: "",
+	err: names.InvalidTagError("", ""),
+}, {
+	tag:      "subnet-10.20.0.0/16",
+	expected: names.NewSubnetTag("10.20.0.0/16"),
+}, {
+	tag:      "subnet-2001:db8::/32",
+	expected: names.NewSubnetTag("2001:db8::/32"),
+}, {
+	tag: "subnet-fe80::3%zone1/10",
+	err: names.InvalidTagError("subnet-fe80::3%zone1/10", names.SubnetTagKind),
+}, {
+	tag: "subnet-10.20.30.40/16",
+	err: names.InvalidTagError("subnet-10.20.30.40/16", names.SubnetTagKind),
+}, {
+	tag: "subnet-2001:db8::123/32",
+	err: names.InvalidTagError("subnet-2001:db8::123/32", names.SubnetTagKind),
+}, {
+	tag: "subnet-foo",
+	err: names.InvalidTagError("subnet-foo", names.SubnetTagKind),
+}, {
+	tag: "subnet-",
+	err: names.InvalidTagError("subnet-", names.SubnetTagKind),
+}, {
+	tag: "foobar",
+	err: names.InvalidTagError("foobar", ""),
+}, {
+	tag: "unit-foo-0",
+	err: names.InvalidTagError("unit-foo-0", names.SubnetTagKind),
+}}
+
+func (s *subnetSuite) TestParseSubnetTag(c *gc.C) {
+	for i, t := range parseSubnetTagTests {
+		c.Logf("test %d: %s", i, t.tag)
+		got, err := names.ParseSubnetTag(t.tag)
+		if err != nil || t.err != nil {
+			c.Check(err, gc.DeepEquals, t.err)
+			continue
+		}
+		c.Check(got, gc.FitsTypeOf, t.expected)
+		c.Check(got, gc.Equals, t.expected)
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -57,7 +57,7 @@ func validKinds(kind string) bool {
 	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind,
 		RelationTagKind, NetworkTagKind, ActionTagKind, VolumeTagKind,
 		CharmTagKind, StorageTagKind, FilesystemTagKind, IPAddressTagKind,
-		SpaceTagKind:
+		SpaceTagKind, SubnetTagKind:
 		return true
 	}
 	return false
@@ -150,6 +150,11 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewIPAddressTag(uuid.String()), nil
+	case SubnetTagKind:
+		if !IsValidSubnet(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewSubnetTag(id), nil
 	case SpaceTagKind:
 		if !IsValidSpace(id) {
 			return nil, invalidTagError(tag, kind)

--- a/tag_test.go
+++ b/tag_test.go
@@ -36,6 +36,9 @@ var tagKindTests = []struct {
 	{tag: "filesystem-0", kind: names.FilesystemTagKind},
 	{tag: "ipaddress", err: `"ipaddress" is not a valid tag`},
 	{tag: "ipaddress-42424242-1111-2222-3333-0123456789ab", kind: names.IPAddressTagKind},
+	{tag: "subnet", err: `"subnet" is not a valid tag`},
+	{tag: "subnet-10.20.0.0/16", kind: names.SubnetTagKind},
+	{tag: "subnet-2001:db8::/32", kind: names.SubnetTagKind},
 	{tag: "space", err: `"space" is not a valid tag`},
 	{tag: "space-42", kind: names.SpaceTagKind},
 }
@@ -187,6 +190,19 @@ var parseTagTests = []struct {
 	expectType: names.IPAddressTag{},
 	resultId:   "42424242-1111-2222-3333-0123456789ab",
 }, {
+	tag:       "subnet-",
+	resultErr: `"subnet-" is not a valid subnet tag`,
+}, {
+	tag:        "subnet-10.20.0.0/16",
+	expectKind: names.SubnetTagKind,
+	expectType: names.SubnetTag{},
+	resultId:   "10.20.0.0/16",
+}, {
+	tag:        "subnet-2001:db8::/32",
+	expectKind: names.SubnetTagKind,
+	expectType: names.SubnetTag{},
+	resultId:   "2001:db8::/32",
+}, {
 	tag:       "space-",
 	resultErr: `"space-" is not a valid space tag`,
 }, {
@@ -209,6 +225,7 @@ var makeTag = map[string]func(string) names.Tag{
 	names.FilesystemTagKind: func(tag string) names.Tag { return names.NewFilesystemTag(tag) },
 	names.StorageTagKind:    func(tag string) names.Tag { return names.NewStorageTag(tag) },
 	names.IPAddressTagKind:  func(tag string) names.Tag { return names.NewIPAddressTag(tag) },
+	names.SubnetTagKind:     func(tag string) names.Tag { return names.NewSubnetTag(tag) },
 	names.SpaceTagKind:      func(tag string) names.Tag { return names.NewSpaceTag(tag) },
 }
 


### PR DESCRIPTION
Subnet tags have the format "subnet-<CIDR>", where CIDR is a valid IPv4
or IPv6 CIDR, accepted by net.ParseCIDR() and having a matching
*net.IPNet.String() value after parsing. For example,
"subnet-10.20.30.40/16" is not valid, as it needs to be written as
"subnet-10.20.0.0/16".

(Review request: http://reviews.vapour.ws/r/2049/)