### PR TITLE
simpler user invariant: username has "@" => username is not local

### DIFF
--- a/user.go
+++ b/user.go
@@ -9,8 +9,7 @@ import (
 )
 
 const (
-	UserTagKind     = "user"
-	LocalUserDomain = "local"
+	UserTagKind = "user"
 )
 
 var (
@@ -25,7 +24,7 @@ var (
 // IsValidUser returns whether id is a valid user id.
 // Valid users may or may not be qualified with an
 // @domain suffix. Examples of valid users include
-// bob, bob@local, bob@somewhere-else, 0-a-f@123.
+// bob, bob@somewhere, bob@somewhere-else, 0-a-f@123.
 func IsValidUser(id string) bool {
 	return validName.MatchString(id)
 }
@@ -39,9 +38,9 @@ func IsValidUserName(name string) bool {
 }
 
 // IsValidUserDomain returns whether the given user
-// domain is valid.
+// domain is valid. Local users have an empty domain.
 func IsValidUserDomain(domain string) bool {
-	return validUserName.MatchString(domain)
+	return domain == "" || validUserName.MatchString(domain)
 }
 
 // UserTag represents a user that may be stored locally
@@ -69,25 +68,15 @@ func (t UserTag) Id() string {
 // without its associated domain.
 func (t UserTag) Name() string { return t.name }
 
-// Canonical returns the user name and its domain in canonical form.
-// Specifically, user tags in the local domain will always return an
-// @local prefix, regardless of the id the user was created with. This
-// is the only difference from the Id method.
-func (t UserTag) Canonical() string {
-	return t.name + "@" + t.Domain()
-}
-
 // IsLocal returns true if the tag represents a local user.
 func (t UserTag) IsLocal() bool {
-	return t.Domain() == LocalUserDomain
+	return t.Domain() == ""
 }
 
-// Domain returns the user domain. Users in the local database
-// are from the LocalDomain. Other users are considered 'remote' users.
+// Domain returns the user domain. Users in the local database are from
+// the local domain, represented as the empty string. Other users are
+// considered 'remote' users.
 func (t UserTag) Domain() string {
-	if t.domain == "" {
-		return LocalUserDomain
-	}
 	return t.domain
 }
 
@@ -120,7 +109,7 @@ func NewLocalUserTag(name string) UserTag {
 	if !IsValidUserName(name) {
 		panic(fmt.Sprintf("invalid user name %q", name))
 	}
-	return UserTag{name: name, domain: LocalUserDomain}
+	return UserTag{name: name}
 }
 
 // ParseUserTag parses a user tag string.


### PR DESCRIPTION
We lose the concept of "local" as a special name, leading to a much
simpler invariant - a username is external if and only if it has an "@" suffix.
The local domain is intuitively represented by the empty string.

This means that there is no need for the Canonical method, as users
are always in canonical form, and it also means that users as stored
currently in the juju state are already in canonical form as local users,
so there will be no need for a migration when we add information about
external users to the user database.


(Review request: http://reviews.vapour.ws/r/2867/)