### PR TITLE
Add new model tag

### DIFF
--- a/environ.go
+++ b/environ.go
@@ -3,17 +3,12 @@
 
 package names
 
-import (
-	"regexp"
-)
-
+// EnvironTagKind is DEPRECATED: model tags are used instead.
 const EnvironTagKind = "environment"
 
 type EnvironTag struct {
 	uuid string
 }
-
-var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 
 // NewEnvironTag returns the tag of an environment with the given environment UUID.
 func NewEnvironTag(uuid string) EnvironTag {

--- a/model.go
+++ b/model.go
@@ -9,34 +9,34 @@ import (
 
 const ModelTagKind = "model"
 
-// EnvironModel represents a tag used to describe a model.
-type EnvironModel struct {
+// ModelTag represents a tag used to describe a model.
+type ModelTag struct {
 	uuid string
 }
 
 var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 
 // NewModelTag returns the tag of an model with the given model UUID.
-func NewModelTag(uuid string) EnvironModel {
-	return EnvironModel{uuid: uuid}
+func NewModelTag(uuid string) ModelTag {
+	return ModelTag{uuid: uuid}
 }
 
 // ParseModelTag parses an environ tag string.
-func ParseModelTag(modelTag string) (EnvironModel, error) {
+func ParseModelTag(modelTag string) (ModelTag, error) {
 	tag, err := ParseTag(modelTag)
 	if err != nil {
-		return EnvironModel{}, err
+		return ModelTag{}, err
 	}
-	et, ok := tag.(EnvironModel)
+	et, ok := tag.(ModelTag)
 	if !ok {
-		return EnvironModel{}, invalidTagError(modelTag, ModelTagKind)
+		return ModelTag{}, invalidTagError(modelTag, ModelTagKind)
 	}
 	return et, nil
 }
 
-func (t EnvironModel) String() string { return t.Kind() + "-" + t.Id() }
-func (t EnvironModel) Kind() string   { return ModelTagKind }
-func (t EnvironModel) Id() string     { return t.uuid }
+func (t ModelTag) String() string { return t.Kind() + "-" + t.Id() }
+func (t ModelTag) Kind() string   { return ModelTagKind }
+func (t ModelTag) Id() string     { return t.uuid }
 
 // IsValidModel returns whether id is a valid model UUID.
 func IsValidModel(id string) bool {

--- a/model.go
+++ b/model.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"regexp"
+)
+
+const ModelTagKind = "model"
+
+// EnvironModelTag represents a tag used to describe a model.
+type EnvironModelTag struct {
+	uuid string
+}
+
+var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
+
+// NewModelTag returns the tag of an model with the given model UUID.
+func NewModelTag(uuid string) EnvironModelTag {
+	return EnvironModelTag{uuid: uuid}
+}
+
+// ParseModelTag parses an environ tag string.
+func ParseModelTag(ModelTag string) (EnvironModelTag, error) {
+	tag, err := ParseTag(ModelTag)
+	if err != nil {
+		return EnvironModelTag{}, err
+	}
+	et, ok := tag.(EnvironModelTag)
+	if !ok {
+		return EnvironModelTag{}, invalidTagError(ModelTag, ModelTagKind)
+	}
+	return et, nil
+}
+
+func (t EnvironModelTag) String() string { return t.Kind() + "-" + t.Id() }
+func (t EnvironModelTag) Kind() string   { return ModelTagKind }
+func (t EnvironModelTag) Id() string     { return t.uuid }
+
+// IsValidModel returns whether id is a valid model UUID.
+func IsValidModel(id string) bool {
+	return validUUID.MatchString(id)
+}

--- a/model.go
+++ b/model.go
@@ -9,34 +9,34 @@ import (
 
 const ModelTagKind = "model"
 
-// EnvironModelTag represents a tag used to describe a model.
-type EnvironModelTag struct {
+// EnvironModel represents a tag used to describe a model.
+type EnvironModel struct {
 	uuid string
 }
 
 var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 
 // NewModelTag returns the tag of an model with the given model UUID.
-func NewModelTag(uuid string) EnvironModelTag {
-	return EnvironModelTag{uuid: uuid}
+func NewModelTag(uuid string) EnvironModel {
+	return EnvironModel{uuid: uuid}
 }
 
 // ParseModelTag parses an environ tag string.
-func ParseModelTag(ModelTag string) (EnvironModelTag, error) {
-	tag, err := ParseTag(ModelTag)
+func ParseModelTag(modelTag string) (EnvironModel, error) {
+	tag, err := ParseTag(modelTag)
 	if err != nil {
-		return EnvironModelTag{}, err
+		return EnvironModel{}, err
 	}
-	et, ok := tag.(EnvironModelTag)
+	et, ok := tag.(EnvironModel)
 	if !ok {
-		return EnvironModelTag{}, invalidTagError(ModelTag, ModelTagKind)
+		return EnvironModel{}, invalidTagError(modelTag, ModelTagKind)
 	}
 	return et, nil
 }
 
-func (t EnvironModelTag) String() string { return t.Kind() + "-" + t.Id() }
-func (t EnvironModelTag) Kind() string   { return ModelTagKind }
-func (t EnvironModelTag) Id() string     { return t.uuid }
+func (t EnvironModel) String() string { return t.Kind() + "-" + t.Id() }
+func (t EnvironModel) Kind() string   { return ModelTagKind }
+func (t EnvironModel) Id() string     { return t.uuid }
 
 // IsValidModel returns whether id is a valid model UUID.
 func IsValidModel(id string) bool {

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,49 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/names"
+)
+
+type modelSuite struct{}
+
+var _ = gc.Suite(&modelSuite{})
+
+var parseModelTagTests = []struct {
+	tag      string
+	expected names.Tag
+	err      error
+}{{
+	tag: "",
+	err: names.InvalidTagError("", ""),
+}, {
+	tag:      "model-f47ac10b-58cc-4372-a567-0e02b2c3d479",
+	expected: names.NewModelTag("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+}, {
+	tag: "dave",
+	err: names.InvalidTagError("dave", ""),
+	//}, {
+	// TODO(dfc) passes, but should not
+	//	tag: "model-",
+	//	err: names.InvalidTagError("model", ""),
+}, {
+	tag: "service-dave",
+	err: names.InvalidTagError("service-dave", names.ModelTagKind),
+}}
+
+func (s *modelSuite) TestParseModelTag(c *gc.C) {
+	for i, t := range parseModelTagTests {
+		c.Logf("test %d: %s", i, t.tag)
+		got, err := names.ParseModelTag(t.tag)
+		if err != nil || t.err != nil {
+			c.Check(err, gc.DeepEquals, t.err)
+			continue
+		}
+		c.Check(got, gc.FitsTypeOf, t.expected)
+		c.Check(got, gc.Equals, t.expected)
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -63,7 +63,7 @@ func validKinds(kind string) bool {
 	case UnitTagKind, MachineTagKind, ServiceTagKind, EnvironTagKind, UserTagKind,
 		RelationTagKind, NetworkTagKind, ActionTagKind, VolumeTagKind,
 		CharmTagKind, StorageTagKind, FilesystemTagKind, IPAddressTagKind,
-		SpaceTagKind, SubnetTagKind, PayloadTagKind:
+		SpaceTagKind, SubnetTagKind, PayloadTagKind, ModelTagKind:
 		return true
 	}
 	return false
@@ -111,6 +111,11 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewEnvironTag(id), nil
+	case ModelTagKind:
+		if !IsValidModel(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewModelTag(id), nil
 	case RelationTagKind:
 		id = relationTagSuffixToKey(id)
 		if !IsValidRelation(id) {

--- a/tag_test.go
+++ b/tag_test.go
@@ -22,6 +22,7 @@ var tagKindTests = []struct {
 	{tag: "machine-42", kind: names.MachineTagKind},
 	{tag: "service-foo", kind: names.ServiceTagKind},
 	{tag: "environment-42", kind: names.EnvironTagKind},
+	{tag: "model-42", kind: names.ModelTagKind},
 	{tag: "user-admin", kind: names.UserTagKind},
 	{tag: "relation-service1.rel1#other-svc.other-rel2", kind: names.RelationTagKind},
 	{tag: "relation-service.peerRelation", kind: names.RelationTagKind},
@@ -109,6 +110,11 @@ var parseTagTests = []struct {
 	expectType: names.EnvironTag{},
 	resultId:   "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 }, {
+	tag:        "model-f47ac10b-58cc-4372-a567-0e02b2c3d479",
+	expectKind: names.ModelTagKind,
+	expectType: names.EnvironModelTag{},
+	resultId:   "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+}, {
 	tag:        "relation-my-svc1.myrel1#other-svc.other-rel2",
 	expectKind: names.RelationTagKind,
 	expectType: names.RelationTag{},
@@ -123,6 +129,11 @@ var parseTagTests = []struct {
 	expectKind: names.EnvironTagKind,
 	expectType: names.EnvironTag{},
 	resultErr:  `"environment-/" is not a valid environment tag`,
+}, {
+	tag:        "model-/",
+	expectKind: names.ModelTagKind,
+	expectType: names.EnvironModelTag{},
+	resultErr:  `"model-/" is not a valid model tag`,
 }, {
 	tag:        "user-foo",
 	expectKind: names.UserTagKind,
@@ -218,6 +229,7 @@ var makeTag = map[string]func(string) names.Tag{
 	names.ServiceTagKind:    func(tag string) names.Tag { return names.NewServiceTag(tag) },
 	names.RelationTagKind:   func(tag string) names.Tag { return names.NewRelationTag(tag) },
 	names.EnvironTagKind:    func(tag string) names.Tag { return names.NewEnvironTag(tag) },
+	names.ModelTagKind:      func(tag string) names.Tag { return names.NewModelTag(tag) },
 	names.UserTagKind:       func(tag string) names.Tag { return names.NewUserTag(tag) },
 	names.NetworkTagKind:    func(tag string) names.Tag { return names.NewNetworkTag(tag) },
 	names.ActionTagKind:     func(tag string) names.Tag { return names.NewActionTag(tag) },

--- a/tag_test.go
+++ b/tag_test.go
@@ -112,7 +112,7 @@ var parseTagTests = []struct {
 }, {
 	tag:        "model-f47ac10b-58cc-4372-a567-0e02b2c3d479",
 	expectKind: names.ModelTagKind,
-	expectType: names.EnvironModel{},
+	expectType: names.ModelTag{},
 	resultId:   "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 }, {
 	tag:        "relation-my-svc1.myrel1#other-svc.other-rel2",
@@ -132,7 +132,7 @@ var parseTagTests = []struct {
 }, {
 	tag:        "model-/",
 	expectKind: names.ModelTagKind,
-	expectType: names.EnvironModel{},
+	expectType: names.ModelTag{},
 	resultErr:  `"model-/" is not a valid model tag`,
 }, {
 	tag:        "user-foo",

--- a/tag_test.go
+++ b/tag_test.go
@@ -112,7 +112,7 @@ var parseTagTests = []struct {
 }, {
 	tag:        "model-f47ac10b-58cc-4372-a567-0e02b2c3d479",
 	expectKind: names.ModelTagKind,
-	expectType: names.EnvironModelTag{},
+	expectType: names.EnvironModel{},
 	resultId:   "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 }, {
 	tag:        "relation-my-svc1.myrel1#other-svc.other-rel2",
@@ -132,7 +132,7 @@ var parseTagTests = []struct {
 }, {
 	tag:        "model-/",
 	expectKind: names.ModelTagKind,
-	expectType: names.EnvironModelTag{},
+	expectType: names.EnvironModel{},
 	resultErr:  `"model-/" is not a valid model tag`,
 }, {
 	tag:        "user-foo",


### PR DESCRIPTION
Add new model tag.
A v2 API change will be required to remove the deprecated environment tag.

(Review request: http://reviews.vapour.ws/r/3604/)