### PR TITLE
Use the payload class name as the ID.

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -4,6 +4,8 @@
 package names
 
 import (
+	"regexp"
+
 	"github.com/juju/utils"
 )
 
@@ -11,12 +13,17 @@ const (
 	// PayloadTagKind is used as the prefix for the string
 	// representation of payload tags.
 	PayloadTagKind = "payload"
+
+	payloadClass = "([a-zA-Z][a-zA-Z0-9]*)"
 )
 
+var validPayload = regexp.MustCompile("^" + payloadClass + "$")
+
 // IsValidPayload returns whether id is a valid Juju ID for
-// a charm payload. The ID must be a valid UUID.
+// a charm payload. The ID must be a valid "identifier". For
+// compatibility with Juju 1.25, UUIDs are also supported.
 func IsValidPayload(id string) bool {
-	return utils.IsValidUUIDString(id)
+	return validPayload.MatchString(id) || utils.IsValidUUIDString(id)
 }
 
 // PayloadTag represents a charm payload.

--- a/payload.go
+++ b/payload.go
@@ -21,10 +21,14 @@ const (
 var validPayload = regexp.MustCompile("^" + payloadClass + "$")
 
 // IsValidPayload returns whether id is a valid Juju ID for
-// a charm payload. The ID must be a valid "identifier". For
-// compatibility with Juju 1.25, UUIDs are also supported.
+// a charm payload. The ID must be a valid alpha-numeric (plus hyphens).
 func IsValidPayload(id string) bool {
-	return validPayload.MatchString(id) || utils.IsValidUUIDString(id)
+	return validPayload.MatchString(id)
+}
+
+// For compatibility with Juju 1.25, UUIDs are also supported.
+func isValidPayload(id string) bool {
+	return IsValidPayload(id) || utils.IsValidUUIDString(id)
 }
 
 // PayloadTag represents a charm payload.

--- a/payload.go
+++ b/payload.go
@@ -14,7 +14,7 @@ const (
 	// representation of payload tags.
 	PayloadTagKind = "payload"
 
-	payloadClass = "([a-zA-Z][a-zA-Z0-9]*)"
+	payloadClass = "([a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)"
 )
 
 var validPayload = regexp.MustCompile("^" + payloadClass + "$")

--- a/payload.go
+++ b/payload.go
@@ -14,6 +14,7 @@ const (
 	// representation of payload tags.
 	PayloadTagKind = "payload"
 
+	// This can be expanded later, as needed.
 	payloadClass = "([a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)"
 )
 

--- a/payload_test.go
+++ b/payload_test.go
@@ -39,7 +39,7 @@ func (s *payloadSuite) TestIsValidPayload(c *gc.C) {
 		expect bool
 	}{
 		{"", false},
-		{"spam", false},
+		{"spam", true},
 
 		{"f47ac10b-58cc-4372-a567-0e02b2c3d479", true},
 	} {
@@ -62,11 +62,14 @@ func (s *payloadSuite) TestParsePayloadTag(c *gc.C) {
 		tag: "payload-",
 		err: names.InvalidTagError("payload-", names.PayloadTagKind),
 	}, {
-		tag: "payload-spam",
-		err: names.InvalidTagError("payload-spam", names.PayloadTagKind),
+		tag:      "payload-spam",
+		expected: names.NewPayloadTag("spam"),
 	}, {
 		tag:      "payload-f47ac10b-58cc-4372-a567-0e02b2c3d479",
 		expected: names.NewPayloadTag("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+	}, {
+		tag: "spam",
+		err: names.InvalidTagError("spam", ""),
 	}, {
 		tag: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
 		err: names.InvalidTagError("f47ac10b-58cc-4372-a567-0e02b2c3d479", ""),

--- a/payload_test.go
+++ b/payload_test.go
@@ -39,7 +39,9 @@ func (s *payloadSuite) TestIsValidPayload(c *gc.C) {
 		expect bool
 	}{
 		{"", false},
+		{"spam-", false},
 		{"spam", true},
+		{"spam-and-eggs", true},
 
 		{"f47ac10b-58cc-4372-a567-0e02b2c3d479", true},
 	} {

--- a/tag.go
+++ b/tag.go
@@ -167,7 +167,7 @@ func ParseTag(tag string) (Tag, error) {
 		}
 		return NewSpaceTag(id), nil
 	case PayloadTagKind:
-		if !IsValidPayload(id) {
+		if !isValidPayload(id) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewPayloadTag(id), nil


### PR DESCRIPTION
Juju was using an unrelated UUID to identify payloads.  Doing so proved unnecessary.  This patch aligns with upcoming changes in core.  It updates the payload tag to support identifying payloads by their class name.

(Review request: http://reviews.vapour.ws/r/4875/)