### PR TITLE
names: add "cloud" tag kind

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -1,0 +1,51 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const CloudTagKind = "cloud"
+
+var (
+	cloudSnippet = "[a-zA-Z0-9][a-zA-Z0-9.-]*"
+	validCloud   = regexp.MustCompile("^" + cloudSnippet + "$")
+)
+
+type CloudTag struct {
+	id string
+}
+
+func (t CloudTag) String() string { return t.Kind() + "-" + t.id }
+func (t CloudTag) Kind() string   { return CloudTagKind }
+func (t CloudTag) Id() string     { return t.id }
+
+// NewCloudTag returns the tag for the cloud with the given ID.
+// It will panic if the given cloud ID is not valid.
+func NewCloudTag(id string) CloudTag {
+	if !IsValidCloud(id) {
+		panic(fmt.Sprintf("%q is not a valid cloud ID", id))
+	}
+	return CloudTag{id}
+}
+
+// ParseCloudTag parses a cloud tag string.
+func ParseCloudTag(cloudTag string) (CloudTag, error) {
+	tag, err := ParseTag(cloudTag)
+	if err != nil {
+		return CloudTag{}, err
+	}
+	dt, ok := tag.(CloudTag)
+	if !ok {
+		return CloudTag{}, invalidTagError(cloudTag, CloudTagKind)
+	}
+	return dt, nil
+}
+
+// IsValidCloud returns whether id is a valid cloud ID.
+func IsValidCloud(id string) bool {
+	return validCloud.MatchString(id)
+}

--- a/cloud_test.go
+++ b/cloud_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/names.v2"
+)
+
+type cloudSuite struct{}
+
+var _ = gc.Suite(&cloudSuite{})
+
+func (s *cloudSuite) TestCloudTag(c *gc.C) {
+	for i, t := range []struct {
+		input  string
+		string string
+	}{
+		{
+			input:  "bob",
+			string: "cloud-bob",
+		},
+	} {
+		c.Logf("test %d: %s", i, t.input)
+		cloudTag := names.NewCloudTag(t.input)
+		c.Check(cloudTag.String(), gc.Equals, t.string)
+		c.Check(cloudTag.Id(), gc.Equals, t.input)
+	}
+}
+
+func (s *cloudSuite) TestIsValidCloud(c *gc.C) {
+	for i, t := range []struct {
+		string string
+		expect bool
+	}{
+		{"", false},
+		{"bob", true},
+		{"Bob", true},
+		{"bOB", true},
+		{"b^b", false},
+		{"bob1", true},
+		{"bob-1", true},
+		{"bob.1", true},
+		{"1bob", true},
+		{"1-bob", true},
+		{"1+bob", false},
+		{"1.bob", true},
+		{"a", true},
+		{"0foo", true},
+		{"foo bar", false},
+		{"bar{}", false},
+		{"bar+foo", false},
+		{"bar_foo", false},
+		{"bar!", false},
+		{"bar^", false},
+		{"bar*", false},
+		{"foo=bar", false},
+		{"foo?", false},
+		{"[bar]", false},
+		{"'foo'", false},
+		{"%bar", false},
+		{"&bar", false},
+		{"#1foo", false},
+		{"bar@", false},
+		{"@local", false},
+		{"not/valid", false},
+	} {
+		c.Logf("test %d: %s", i, t.string)
+		c.Assert(names.IsValidCloud(t.string), gc.Equals, t.expect, gc.Commentf("%s", t.string))
+	}
+}
+
+func (s *cloudSuite) TestParseCloudTag(c *gc.C) {
+	for i, t := range []struct {
+		tag      string
+		expected names.Tag
+		err      error
+	}{{
+		tag: "",
+		err: names.InvalidTagError("", ""),
+	}, {
+		tag:      "cloud-aws",
+		expected: names.NewCloudTag("aws"),
+	}, {
+		tag: "aws",
+		err: names.InvalidTagError("aws", ""),
+	}, {
+		tag: "unit-aws",
+		err: names.InvalidTagError("unit-aws", names.UnitTagKind), // not a valid unit name either
+	}, {
+		tag: "application-aws",
+		err: names.InvalidTagError("application-aws", names.CloudTagKind),
+	}} {
+		c.Logf("test %d: %s", i, t.tag)
+		got, err := names.ParseCloudTag(t.tag)
+		if err != nil || t.err != nil {
+			c.Check(err, gc.DeepEquals, t.err)
+			continue
+		}
+		c.Check(got, gc.FitsTypeOf, t.expected)
+		c.Check(got, gc.Equals, t.expected)
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -63,7 +63,7 @@ func validKinds(kind string) bool {
 	case UnitTagKind, MachineTagKind, ApplicationTagKind, EnvironTagKind, UserTagKind,
 		RelationTagKind, ActionTagKind, VolumeTagKind, CharmTagKind, StorageTagKind,
 		FilesystemTagKind, IPAddressTagKind, SpaceTagKind, SubnetTagKind,
-		PayloadTagKind, ModelTagKind:
+		PayloadTagKind, ModelTagKind, CloudTagKind:
 		return true
 	}
 	return false
@@ -171,6 +171,11 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewPayloadTag(id), nil
+	case CloudTagKind:
+		if !IsValidCloud(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewCloudTag(id), nil
 	default:
 		return nil, invalidTagError(tag, "")
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -41,6 +41,8 @@ var tagKindTests = []struct {
 	{tag: "subnet-2001:db8::/32", kind: names.SubnetTagKind},
 	{tag: "space", err: `"space" is not a valid tag`},
 	{tag: "space-42", kind: names.SpaceTagKind},
+	{tag: "cloud", err: `"cloud" is not a valid tag`},
+	{tag: "cloud-aws", kind: names.CloudTagKind},
 }
 
 func (*tagSuite) TestTagKind(c *gc.C) {


### PR DESCRIPTION
Add a tag kind for identifying clouds. This will
be used in the Juju API when querying cloud details,
and querying/updating cloud credentials.

(Review request: http://reviews.vapour.ws/r/5146/)