### PR TITLE
Add CloudCredentialTag

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -29,7 +29,7 @@ var (
 	CharmNameSnippet = "[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*"
 
 	localSchemaSnippet      = "local:"
-	charmStoreSchemaSnippet = "cs:(~" + validUserPart + "/)?"
+	charmStoreSchemaSnippet = "cs:(~" + validUserNameSnippet + "/)?"
 	revisionSnippet         = "(-1|0|[1-9][0-9]*)"
 
 	validCharmRegEx = regexp.MustCompile("^(" +

--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -1,0 +1,98 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const CloudCredentialTagKind = "cloudcred"
+
+var (
+	cloudCredentialNameSnippet = "[a-zA-Z][a-zA-Z0-9.-]*"
+	validCloudCredentialName   = regexp.MustCompile("^" + cloudCredentialNameSnippet + "$")
+	validCloudCredential       = regexp.MustCompile(
+		"^" +
+			"(" + cloudSnippet + ")" +
+			"/(" + validUserSnippet + ")" + // credential owner
+			"/(" + cloudCredentialNameSnippet + ")" +
+			"$",
+	)
+)
+
+type CloudCredentialTag struct {
+	cloud CloudTag
+	owner UserTag
+	name  string
+}
+
+// Kind is part of the Tag interface.
+func (t CloudCredentialTag) Kind() string { return CloudCredentialTagKind }
+
+// Id is part of the Tag interface.
+func (t CloudCredentialTag) Id() string {
+	return fmt.Sprintf("%s/%s/%s", t.cloud.Id(), t.owner.Id(), t.name)
+}
+
+// String is part of the Tag interface.
+func (t CloudCredentialTag) String() string {
+	return fmt.Sprintf("%s-%s-%s-%s", t.Kind(), t.cloud.Id(), t.owner.Id(), t.name)
+}
+
+// Cloud returns the tag of the cloud to which the credential pertains.
+func (t CloudCredentialTag) Cloud() CloudTag {
+	return t.cloud
+}
+
+// Owner returns the tag of the user that owns the credential.
+func (t CloudCredentialTag) Owner() UserTag {
+	return t.owner
+}
+
+// Name returns the cloud credential name, excluding the
+// cloud and owner qualifiers.
+func (t CloudCredentialTag) Name() string {
+	return t.name
+}
+
+// NewCloudCredentialTag returns the tag for the cloud with the given ID.
+// It will panic if the given cloud ID is not valid.
+func NewCloudCredentialTag(id string) CloudCredentialTag {
+	parts := validCloudCredential.FindStringSubmatch(id)
+	if len(parts) != 4 {
+		panic(fmt.Sprintf("%q is not a valid cloud credential ID", id))
+	}
+	cloud := NewCloudTag(parts[1])
+	owner := NewUserTag(parts[2])
+	return CloudCredentialTag{cloud, owner, parts[3]}
+}
+
+// ParseCloudCredentialTag parses a cloud tag string.
+func ParseCloudCredentialTag(s string) (CloudCredentialTag, error) {
+	tag, err := ParseTag(s)
+	if err != nil {
+		return CloudCredentialTag{}, err
+	}
+	dt, ok := tag.(CloudCredentialTag)
+	if !ok {
+		return CloudCredentialTag{}, invalidTagError(s, CloudCredentialTagKind)
+	}
+	return dt, nil
+}
+
+// IsValidCloudCredential returns whether id is a valid cloud credential ID.
+func IsValidCloudCredential(id string) bool {
+	return validCloudCredential.MatchString(id)
+}
+
+// IsValidCloudCredentialName returns whether name is a valid cloud credential name.
+func IsValidCloudCredentialName(name string) bool {
+	return validCloudCredentialName.MatchString(name)
+}
+
+func cloudCredentialTagSuffixToId(s string) string {
+	return strings.Replace(s, "-", "/", -1)
+}

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/names.v2"
+)
+
+type cloudCredentialSuite struct{}
+
+var _ = gc.Suite(&cloudCredentialSuite{})
+
+func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
+	for i, t := range []struct {
+		input  string
+		string string
+		cloud  names.CloudTag
+		owner  names.UserTag
+		name   string
+	}{
+		{
+			input:  "aws/bob/foo",
+			string: "cloudcred-aws-bob-foo",
+			cloud:  names.NewCloudTag("aws"),
+			owner:  names.NewUserTag("bob"),
+			name:   "foo",
+		},
+	} {
+		c.Logf("test %d: %s", i, t.input)
+		cloudTag := names.NewCloudCredentialTag(t.input)
+		c.Check(cloudTag.String(), gc.Equals, t.string)
+		c.Check(cloudTag.Id(), gc.Equals, t.input)
+	}
+}
+
+func (s *cloudCredentialSuite) TestIsValidCloudCredential(c *gc.C) {
+	for i, t := range []struct {
+		string string
+		expect bool
+	}{
+		{"", false},
+		{"aws/bob/foo", true},
+		{"aws/bob@local/foo", true},
+		{"/bob/foo", false},
+		{"aws//foo", false},
+		{"aws/bob/", false},
+	} {
+		c.Logf("test %d: %s", i, t.string)
+		c.Assert(names.IsValidCloudCredential(t.string), gc.Equals, t.expect, gc.Commentf("%s", t.string))
+	}
+}
+
+func (s *cloudCredentialSuite) TestIsValidCloudCredentialName(c *gc.C) {
+	for i, t := range []struct {
+		string string
+		expect bool
+	}{
+		{"", false},
+		{"foo", true},
+		{"f00b4r", true},
+		{"foo-bar", true},
+		{"123", false},
+		{"0foo", false},
+	} {
+		c.Logf("test %d: %s", i, t.string)
+		c.Assert(names.IsValidCloudCredentialName(t.string), gc.Equals, t.expect, gc.Commentf("%s", t.string))
+	}
+}
+
+func (s *cloudCredentialSuite) TestParseCloudCredentialTag(c *gc.C) {
+	for i, t := range []struct {
+		tag      string
+		expected names.Tag
+		err      error
+	}{{
+		tag: "",
+		err: names.InvalidTagError("", ""),
+	}, {
+		tag:      "cloudcred-aws-bob-foo",
+		expected: names.NewCloudCredentialTag("aws/bob/foo"),
+	}, {
+		tag: "foo",
+		err: names.InvalidTagError("foo", ""),
+	}, {
+		tag: "unit-aws",
+		err: names.InvalidTagError("unit-aws", names.UnitTagKind), // not a valid unit name either
+	}} {
+		c.Logf("test %d: %s", i, t.tag)
+		got, err := names.ParseCloudCredentialTag(t.tag)
+		if err != nil || t.err != nil {
+			c.Check(err, gc.DeepEquals, t.err)
+			continue
+		}
+		c.Check(got, gc.FitsTypeOf, t.expected)
+		c.Check(got, gc.Equals, t.expected)
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -63,7 +63,7 @@ func validKinds(kind string) bool {
 	case UnitTagKind, MachineTagKind, ApplicationTagKind, EnvironTagKind, UserTagKind,
 		RelationTagKind, ActionTagKind, VolumeTagKind, CharmTagKind, StorageTagKind,
 		FilesystemTagKind, IPAddressTagKind, SpaceTagKind, SubnetTagKind,
-		PayloadTagKind, ModelTagKind, ControllerTagKind, CloudTagKind:
+		PayloadTagKind, ModelTagKind, ControllerTagKind, CloudTagKind, CloudCredentialTagKind:
 		return true
 	}
 	return false
@@ -182,6 +182,12 @@ func ParseTag(tag string) (Tag, error) {
 			return nil, invalidTagError(tag, kind)
 		}
 		return NewCloudTag(id), nil
+	case CloudCredentialTagKind:
+		id = cloudCredentialTagSuffixToId(id)
+		if !IsValidCloudCredential(id) {
+			return nil, invalidTagError(tag, kind)
+		}
+		return NewCloudCredentialTag(id), nil
 	default:
 		return nil, invalidTagError(tag, "")
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -43,6 +43,8 @@ var tagKindTests = []struct {
 	{tag: "space-42", kind: names.SpaceTagKind},
 	{tag: "cloud", err: `"cloud" is not a valid tag`},
 	{tag: "cloud-aws", kind: names.CloudTagKind},
+	{tag: "cloudcred", err: `"cloudcred" is not a valid tag`},
+	{tag: "cloudcred-aws-admin-foo", kind: names.CloudCredentialTagKind},
 }
 
 func (*tagSuite) TestTagKind(c *gc.C) {
@@ -212,23 +214,35 @@ var parseTagTests = []struct {
 	expectKind: names.SpaceTagKind,
 	expectType: names.SpaceTag{},
 	resultId:   "myspace1",
+}, {
+	tag:        "cloud-aws",
+	expectKind: names.CloudTagKind,
+	expectType: names.CloudTag{},
+	resultId:   "aws",
+}, {
+	tag:        "cloudcred-aws-admin-foo",
+	expectKind: names.CloudCredentialTagKind,
+	expectType: names.CloudCredentialTag{},
+	resultId:   "aws/admin/foo",
 }}
 
 var makeTag = map[string]func(string) names.Tag{
-	names.MachineTagKind:     func(tag string) names.Tag { return names.NewMachineTag(tag) },
-	names.UnitTagKind:        func(tag string) names.Tag { return names.NewUnitTag(tag) },
-	names.ApplicationTagKind: func(tag string) names.Tag { return names.NewApplicationTag(tag) },
-	names.RelationTagKind:    func(tag string) names.Tag { return names.NewRelationTag(tag) },
-	names.EnvironTagKind:     func(tag string) names.Tag { return names.NewEnvironTag(tag) },
-	names.ModelTagKind:       func(tag string) names.Tag { return names.NewModelTag(tag) },
-	names.UserTagKind:        func(tag string) names.Tag { return names.NewUserTag(tag) },
-	names.ActionTagKind:      func(tag string) names.Tag { return names.NewActionTag(tag) },
-	names.VolumeTagKind:      func(tag string) names.Tag { return names.NewVolumeTag(tag) },
-	names.FilesystemTagKind:  func(tag string) names.Tag { return names.NewFilesystemTag(tag) },
-	names.StorageTagKind:     func(tag string) names.Tag { return names.NewStorageTag(tag) },
-	names.IPAddressTagKind:   func(tag string) names.Tag { return names.NewIPAddressTag(tag) },
-	names.SubnetTagKind:      func(tag string) names.Tag { return names.NewSubnetTag(tag) },
-	names.SpaceTagKind:       func(tag string) names.Tag { return names.NewSpaceTag(tag) },
+	names.MachineTagKind:         func(tag string) names.Tag { return names.NewMachineTag(tag) },
+	names.UnitTagKind:            func(tag string) names.Tag { return names.NewUnitTag(tag) },
+	names.ApplicationTagKind:     func(tag string) names.Tag { return names.NewApplicationTag(tag) },
+	names.RelationTagKind:        func(tag string) names.Tag { return names.NewRelationTag(tag) },
+	names.EnvironTagKind:         func(tag string) names.Tag { return names.NewEnvironTag(tag) },
+	names.ModelTagKind:           func(tag string) names.Tag { return names.NewModelTag(tag) },
+	names.UserTagKind:            func(tag string) names.Tag { return names.NewUserTag(tag) },
+	names.ActionTagKind:          func(tag string) names.Tag { return names.NewActionTag(tag) },
+	names.VolumeTagKind:          func(tag string) names.Tag { return names.NewVolumeTag(tag) },
+	names.FilesystemTagKind:      func(tag string) names.Tag { return names.NewFilesystemTag(tag) },
+	names.StorageTagKind:         func(tag string) names.Tag { return names.NewStorageTag(tag) },
+	names.IPAddressTagKind:       func(tag string) names.Tag { return names.NewIPAddressTag(tag) },
+	names.SubnetTagKind:          func(tag string) names.Tag { return names.NewSubnetTag(tag) },
+	names.SpaceTagKind:           func(tag string) names.Tag { return names.NewSpaceTag(tag) },
+	names.CloudTagKind:           func(tag string) names.Tag { return names.NewCloudTag(tag) },
+	names.CloudCredentialTagKind: func(tag string) names.Tag { return names.NewCloudCredentialTag(tag) },
 }
 
 func (*tagSuite) TestParseTag(c *gc.C) {

--- a/user.go
+++ b/user.go
@@ -17,9 +17,10 @@ var (
 	// TODO this does not allow single character usernames or
 	// domains. Is that deliberate?
 	// https://github.com/juju/names/issues/54
-	validUserPart = "[a-zA-Z0-9][a-zA-Z0-9.+-]*[a-zA-Z0-9]"
-	validName     = regexp.MustCompile(fmt.Sprintf("^(?P<name>%s)(?:@(?P<domain>%s))?$", validUserPart, validUserPart))
-	validUserName = regexp.MustCompile("^" + validUserPart + "$")
+	validUserNameSnippet = "[a-zA-Z0-9][a-zA-Z0-9.+-]*[a-zA-Z0-9]"
+	validUserSnippet     = fmt.Sprintf("(?:%s(?:@%s)?)", validUserNameSnippet, validUserNameSnippet)
+	validName            = regexp.MustCompile(fmt.Sprintf("^(?P<name>%s)(?:@(?P<domain>%s))?$", validUserNameSnippet, validUserNameSnippet))
+	validUserName        = regexp.MustCompile("^" + validUserNameSnippet + "$")
 )
 
 // IsValidUser returns whether id is a valid user id.


### PR DESCRIPTION
We add a new tag for identifying cloud credentials
within a Juju controller. A credential tag has three
components: the credential name, its owner (a valid
user), and the cloud to which the credential pertains.

(Review request: http://reviews.vapour.ws/r/5437/)