### PR TITLE
Add CloudCredential.Canonical method

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -34,12 +34,28 @@ func (t CloudCredentialTag) Kind() string { return CloudCredentialTagKind }
 
 // Id is part of the Tag interface.
 func (t CloudCredentialTag) Id() string {
-	return fmt.Sprintf("%s/%s/%s", t.cloud.Id(), t.owner.Id(), t.name)
+	return t.id(false)
 }
 
 // String is part of the Tag interface.
 func (t CloudCredentialTag) String() string {
 	return fmt.Sprintf("%s-%s-%s-%s", t.Kind(), t.cloud.Id(), t.owner.Id(), t.name)
+}
+
+// Canonical returns the cloud credential ID in canonical form.
+// Specifically, the user tag portion will be canonicalized.
+func (t CloudCredentialTag) Canonical() string {
+	return t.id(true)
+}
+
+func (t CloudCredentialTag) id(canonical bool) string {
+	var ownerId string
+	if canonical {
+		ownerId = t.owner.Canonical()
+	} else {
+		ownerId = t.owner.Id()
+	}
+	return fmt.Sprintf("%s/%s/%s", t.cloud.Id(), ownerId, t.name)
 }
 
 // Cloud returns the tag of the cloud to which the credential pertains.

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -15,24 +15,37 @@ var _ = gc.Suite(&cloudCredentialSuite{})
 
 func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
 	for i, t := range []struct {
-		input  string
-		string string
-		cloud  names.CloudTag
-		owner  names.UserTag
-		name   string
+		input     string
+		string    string
+		cloud     names.CloudTag
+		owner     names.UserTag
+		name      string
+		canonical string
 	}{
 		{
-			input:  "aws/bob/foo",
-			string: "cloudcred-aws-bob-foo",
-			cloud:  names.NewCloudTag("aws"),
-			owner:  names.NewUserTag("bob"),
-			name:   "foo",
+			input:     "aws/bob/foo",
+			canonical: "aws/bob@local/foo",
+			string:    "cloudcred-aws-bob-foo",
+			cloud:     names.NewCloudTag("aws"),
+			owner:     names.NewUserTag("bob"),
+			name:      "foo",
+		}, {
+			input:     "aws/bob@remote/foo",
+			canonical: "aws/bob@remote/foo",
+			string:    "cloudcred-aws-bob@remote-foo",
+			cloud:     names.NewCloudTag("aws"),
+			owner:     names.NewUserTag("bob@remote"),
+			name:      "foo",
 		},
 	} {
 		c.Logf("test %d: %s", i, t.input)
 		cloudTag := names.NewCloudCredentialTag(t.input)
 		c.Check(cloudTag.String(), gc.Equals, t.string)
 		c.Check(cloudTag.Id(), gc.Equals, t.input)
+		c.Check(cloudTag.Cloud(), gc.Equals, t.cloud)
+		c.Check(cloudTag.Owner(), gc.Equals, t.owner)
+		c.Check(cloudTag.Name(), gc.Equals, t.name)
+		c.Check(cloudTag.Canonical(), gc.Equals, t.canonical)
 	}
 }
 


### PR DESCRIPTION
Add a method to CloudCredential to return the
canonical form of a cloud credential ID. This
is due to the inclusion of user IDs, which have
canonical and non-canonical forms.

(Review request: http://reviews.vapour.ws/r/5441/)