### PR TITLE
Fix cloud credential tag encoding

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -39,7 +39,7 @@ func (t CloudCredentialTag) Id() string {
 
 // String is part of the Tag interface.
 func (t CloudCredentialTag) String() string {
-	return fmt.Sprintf("%s-%s-%s-%s", t.Kind(), t.cloud.Id(), t.owner.Id(), t.name)
+	return fmt.Sprintf("%s-%s_%s_%s", t.Kind(), t.cloud.Id(), t.owner.Id(), t.name)
 }
 
 // Canonical returns the cloud credential ID in canonical form.
@@ -110,5 +110,5 @@ func IsValidCloudCredentialName(name string) bool {
 }
 
 func cloudCredentialTagSuffixToId(s string) string {
-	return strings.Replace(s, "-", "/", -1)
+	return strings.Replace(s, "_", "/", -1)
 }

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -25,14 +25,14 @@ func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
 		{
 			input:     "aws/bob/foo",
 			canonical: "aws/bob@local/foo",
-			string:    "cloudcred-aws-bob-foo",
+			string:    "cloudcred-aws_bob_foo",
 			cloud:     names.NewCloudTag("aws"),
 			owner:     names.NewUserTag("bob"),
 			name:      "foo",
 		}, {
 			input:     "aws/bob@remote/foo",
 			canonical: "aws/bob@remote/foo",
-			string:    "cloudcred-aws-bob@remote-foo",
+			string:    "cloudcred-aws_bob@remote_foo",
 			cloud:     names.NewCloudTag("aws"),
 			owner:     names.NewUserTag("bob@remote"),
 			name:      "foo",
@@ -92,8 +92,11 @@ func (s *cloudCredentialSuite) TestParseCloudCredentialTag(c *gc.C) {
 		tag: "",
 		err: names.InvalidTagError("", ""),
 	}, {
-		tag:      "cloudcred-aws-bob-foo",
+		tag:      "cloudcred-aws_bob_foo",
 		expected: names.NewCloudCredentialTag("aws/bob/foo"),
+	}, {
+		tag:      "cloudcred-aws-china_bob_foo-manchu",
+		expected: names.NewCloudCredentialTag("aws-china/bob/foo-manchu"),
 	}, {
 		tag: "foo",
 		err: names.InvalidTagError("foo", ""),

--- a/tag_test.go
+++ b/tag_test.go
@@ -44,7 +44,7 @@ var tagKindTests = []struct {
 	{tag: "cloud", err: `"cloud" is not a valid tag`},
 	{tag: "cloud-aws", kind: names.CloudTagKind},
 	{tag: "cloudcred", err: `"cloudcred" is not a valid tag`},
-	{tag: "cloudcred-aws-admin-foo", kind: names.CloudCredentialTagKind},
+	{tag: "cloudcred-aws_admin_foo", kind: names.CloudCredentialTagKind},
 }
 
 func (*tagSuite) TestTagKind(c *gc.C) {
@@ -220,7 +220,7 @@ var parseTagTests = []struct {
 	expectType: names.CloudTag{},
 	resultId:   "aws",
 }, {
-	tag:        "cloudcred-aws-admin-foo",
+	tag:        "cloudcred-aws_admin_foo",
 	expectKind: names.CloudCredentialTagKind,
 	expectType: names.CloudCredentialTag{},
 	resultId:   "aws/admin/foo",


### PR DESCRIPTION
We cannot use "-" to separate the
tag components for cloud credential
tags, as both clouds and credentials
may contain hyphens. Instead, we use
underscores.

(Review request: http://reviews.vapour.ws/r/5446/)