### PR TITLE
Credential names now support @ and _

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -5,6 +5,7 @@ package names
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -12,7 +13,7 @@ import (
 const CloudCredentialTagKind = "cloudcred"
 
 var (
-	cloudCredentialNameSnippet = "[a-zA-Z][a-zA-Z0-9.-]*"
+	cloudCredentialNameSnippet = "[a-zA-Z][a-zA-Z0-9.@_-]*"
 	validCloudCredentialName   = regexp.MustCompile("^" + cloudCredentialNameSnippet + "$")
 	validCloudCredential       = regexp.MustCompile(
 		"^" +
@@ -37,9 +38,16 @@ func (t CloudCredentialTag) Id() string {
 	return t.id(false)
 }
 
+func quoteCredentialSeparator(in string) string {
+	return strings.Replace(in, "_", `%5f`, -1)
+}
+
 // String is part of the Tag interface.
 func (t CloudCredentialTag) String() string {
-	return fmt.Sprintf("%s-%s_%s_%s", t.Kind(), t.cloud.Id(), t.owner.Id(), t.name)
+	return fmt.Sprintf("%s-%s_%s_%s", t.Kind(),
+		quoteCredentialSeparator(t.cloud.Id()),
+		quoteCredentialSeparator(t.owner.Id()),
+		quoteCredentialSeparator(t.name))
 }
 
 // Canonical returns the cloud credential ID in canonical form.
@@ -109,6 +117,7 @@ func IsValidCloudCredentialName(name string) bool {
 	return validCloudCredentialName.MatchString(name)
 }
 
-func cloudCredentialTagSuffixToId(s string) string {
-	return strings.Replace(s, "_", "/", -1)
+func cloudCredentialTagSuffixToId(s string) (string, error) {
+	s = strings.Replace(s, "_", "/", -1)
+	return url.QueryUnescape(s)
 }

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -36,6 +36,20 @@ func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
 			cloud:     names.NewCloudTag("aws"),
 			owner:     names.NewUserTag("bob@remote"),
 			name:      "foo",
+		}, {
+			input:     "aws/bob@remote/foo@somewhere.com",
+			canonical: "aws/bob@remote/foo@somewhere.com",
+			string:    "cloudcred-aws_bob@remote_foo@somewhere.com",
+			cloud:     names.NewCloudTag("aws"),
+			owner:     names.NewUserTag("bob@remote"),
+			name:      "foo@somewhere.com",
+		}, {
+			input:     "aws/bob@remote/foo_bar",
+			canonical: "aws/bob@remote/foo_bar",
+			string:    `cloudcred-aws_bob@remote_foo%5fbar`,
+			cloud:     names.NewCloudTag("aws"),
+			owner:     names.NewUserTag("bob@remote"),
+			name:      "foo_bar",
 		},
 	} {
 		c.Logf("test %d: %s", i, t.input)
@@ -75,11 +89,13 @@ func (s *cloudCredentialSuite) TestIsValidCloudCredentialName(c *gc.C) {
 		{"foo", true},
 		{"f00b4r", true},
 		{"foo-bar", true},
+		{"foo@bar", true},
+		{"foo_bar", true},
 		{"123", false},
 		{"0foo", false},
 	} {
 		c.Logf("test %d: %s", i, t.string)
-		c.Assert(names.IsValidCloudCredentialName(t.string), gc.Equals, t.expect, gc.Commentf("%s", t.string))
+		c.Check(names.IsValidCloudCredentialName(t.string), gc.Equals, t.expect, gc.Commentf("%s", t.string))
 	}
 }
 
@@ -97,6 +113,12 @@ func (s *cloudCredentialSuite) TestParseCloudCredentialTag(c *gc.C) {
 	}, {
 		tag:      "cloudcred-aws-china_bob_foo-manchu",
 		expected: names.NewCloudCredentialTag("aws-china/bob/foo-manchu"),
+	}, {
+		tag:      "cloudcred-aws-china_bob_foo@somewhere.com",
+		expected: names.NewCloudCredentialTag("aws-china/bob/foo@somewhere.com"),
+	}, {
+		tag:      `cloudcred-aws-china_bob_foo%5fbar`,
+		expected: names.NewCloudCredentialTag("aws-china/bob/foo_bar"),
 	}, {
 		tag: "foo",
 		err: names.InvalidTagError("foo", ""),

--- a/tag.go
+++ b/tag.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/utils"
 )
 
@@ -183,7 +184,10 @@ func ParseTag(tag string) (Tag, error) {
 		}
 		return NewCloudTag(id), nil
 	case CloudCredentialTagKind:
-		id = cloudCredentialTagSuffixToId(id)
+		id, err = cloudCredentialTagSuffixToId(id)
+		if err != nil {
+			return nil, errors.Wrap(err, invalidTagError(tag, kind))
+		}
 		if !IsValidCloudCredential(id) {
 			return nil, invalidTagError(tag, kind)
 		}

--- a/tag_test.go
+++ b/tag_test.go
@@ -220,10 +220,10 @@ var parseTagTests = []struct {
 	expectType: names.CloudTag{},
 	resultId:   "aws",
 }, {
-	tag:        "cloudcred-aws_admin_foo",
+	tag:        "cloudcred-aws_admin_foo%5fbar",
 	expectKind: names.CloudCredentialTagKind,
 	expectType: names.CloudCredentialTag{},
-	resultId:   "aws/admin/foo",
+	resultId:   "aws/admin/foo_bar",
 }}
 
 var makeTag = map[string]func(string) names.Tag{


### PR DESCRIPTION
Credential names now may contain @ and _ characters.
Since _ is used as a separator in the tag string, any names containing _ need to be quoted.