### PR TITLE
Allow V3 charm urls in tags

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -11,7 +11,11 @@ import (
 // CharmTagKind specifies charm tag kind
 const CharmTagKind = "charm"
 
-// Valid charm url is of the form
+// Valid charm url can be either in V1 or V3 format. (V2 is a
+// charmstore web URL like https://jujucharms.com/postgresql/105, but
+// that's not valid as a tag.)
+//
+// V1 is of the form:
 // schema:~user/series/name-revision
 // where
 //     schema    is optional and can be either "local" or "cs".
@@ -20,6 +24,10 @@ const CharmTagKind = "charm"
 //     series    is optional and is a valid series name
 //     name      is mandatory and is the name of the charm
 //     revision  is optional and can be -1 if revision is unset
+//
+// V3 is of the form
+// schema:user/name/series/revision
+// with the same fields.
 
 var (
 	// SeriesSnippet is a regular expression representing series
@@ -28,15 +36,24 @@ var (
 	// CharmNameSnippet is a regular expression representing charm name
 	CharmNameSnippet = "[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*"
 
-	localSchemaSnippet      = "local:"
-	charmStoreSchemaSnippet = "cs:(~" + validUserNameSnippet + "/)?"
-	revisionSnippet         = "(-1|0|[1-9][0-9]*)"
+	localSchemaSnippet        = "local:"
+	v1CharmStoreSchemaSnippet = "cs:(~" + validUserNameSnippet + "/)?"
+	revisionSnippet           = "(-1|0|[1-9][0-9]*)"
 
-	validCharmRegEx = regexp.MustCompile("^(" +
+	validV1CharmRegEx = regexp.MustCompile("^(" +
 		localSchemaSnippet + "|" +
-		charmStoreSchemaSnippet + ")?(" +
+		v1CharmStoreSchemaSnippet + ")?(" +
 		SeriesSnippet + "/)?" +
 		CharmNameSnippet + "(-" +
+		revisionSnippet + ")?$")
+
+	v3CharmStoreSchemaSnippet = "(cs:)?(" + validUserNameSnippet + "/)?"
+
+	validV3CharmRegEx = regexp.MustCompile("^(" +
+		localSchemaSnippet + "|" +
+		v3CharmStoreSchemaSnippet + ")" +
+		CharmNameSnippet + "(/" +
+		SeriesSnippet + ")?(/" +
 		revisionSnippet + ")?$")
 )
 
@@ -84,5 +101,5 @@ func ParseCharmTag(charmTag string) (CharmTag, error) {
 
 // IsValidCharm returns whether name is a valid charm url.
 func IsValidCharm(url string) bool {
-	return validCharmRegEx.MatchString(url)
+	return validV1CharmRegEx.MatchString(url) || validV3CharmRegEx.MatchString(url)
 }

--- a/charm_test.go
+++ b/charm_test.go
@@ -17,6 +17,7 @@ type charmSuite struct{}
 var _ = gc.Suite(&charmSuite{})
 
 var validCharmURLs = []string{"charm",
+	// Old-style charm urls.
 	"local:charm",
 	"local:charm--1",
 	"local:charm-1",
@@ -28,6 +29,7 @@ var validCharmURLs = []string{"charm",
 	"cs:~user/series/charm",
 	"cs:~user/series/charm-1",
 	"cs:series/charm",
+	"cs:series/charm-with-long-name",
 	"cs:series/charm-3",
 	"cs:series/charm-0",
 	"cs:charm",
@@ -37,6 +39,25 @@ var validCharmURLs = []string{"charm",
 	"charm-1",
 	"series/charm",
 	"series/charm-1",
+
+	// New-style charm urls.
+	"local:charm-with-long2-name/series/2",
+	"local:charm-with-long2-name/series",
+	"local:charm-with-long2-name/2",
+	"cs:user/charm-with-long-name/series/2",
+	"cs:charm-with-long2-name/series/2",
+	"cs:user/charm-with-long-name/2",
+	"cs:user/charm-with-long-name/series",
+	"cs:charm-with-long-name/2",
+	"cs:charm-with-long-name/series",
+	"cs:user/charm-with-long-name",
+	"user/charm-with-long-name/series/2",
+	"charm-with-long2-name/series/2",
+	"user/charm-with-long-name/2",
+	"user/charm-with-long-name/series",
+	"charm-with-long-name/2",
+	"charm-with-long-name/series",
+	"user/charm-with-long-name",
 }
 
 func (s *charmSuite) TestValidCharmURLs(c *gc.C) {
@@ -54,6 +75,7 @@ func (s *charmSuite) TestInvalidCharmURLs(c *gc.C) {
 		"local:charm--2",             // false: only -1 is a valid negative revision
 		"blah:charm-2",               // false: invalid schema
 		"local:series/charm-01",      // false: revision is funny
+		"local:user/name/series/2",   // false: local charms can't have users
 	}
 	for _, url := range invalidURLs {
 		c.Logf("Processing tag %q", url)
@@ -71,7 +93,6 @@ func (s *charmSuite) TestParseCharmTagValid(c *gc.C) {
 func (s *charmSuite) TestParseCharmTagInvalid(c *gc.C) {
 	invalidTags := []string{"",
 		"blah",
-		"charm-blah/0",
 		"charm",
 		"user-blah",
 	}


### PR DESCRIPTION
Previously charm urls needed to have the format:
`cs:~user/series/name-revision`

Now they can also have the format:
`cs:user/name/series/revision`

The old form is still accepted for backwards compatibility reasons.

Part of http://pad.lv/1584193