### PR TITLE
Only external users require a domain

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -35,7 +35,7 @@ func (t CloudCredentialTag) Kind() string { return CloudCredentialTagKind }
 
 // Id is part of the Tag interface.
 func (t CloudCredentialTag) Id() string {
-	return t.id(false)
+	return fmt.Sprintf("%s/%s/%s", t.cloud.Id(), t.owner.Id(), t.name)
 }
 
 func quoteCredentialSeparator(in string) string {
@@ -48,22 +48,6 @@ func (t CloudCredentialTag) String() string {
 		quoteCredentialSeparator(t.cloud.Id()),
 		quoteCredentialSeparator(t.owner.Id()),
 		quoteCredentialSeparator(t.name))
-}
-
-// Canonical returns the cloud credential ID in canonical form.
-// Specifically, the user tag portion will be canonicalized.
-func (t CloudCredentialTag) Canonical() string {
-	return t.id(true)
-}
-
-func (t CloudCredentialTag) id(canonical bool) string {
-	var ownerId string
-	if canonical {
-		ownerId = t.owner.Canonical()
-	} else {
-		ownerId = t.owner.Id()
-	}
-	return fmt.Sprintf("%s/%s/%s", t.cloud.Id(), ownerId, t.name)
 }
 
 // Cloud returns the tag of the cloud to which the credential pertains.

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -15,41 +15,36 @@ var _ = gc.Suite(&cloudCredentialSuite{})
 
 func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
 	for i, t := range []struct {
-		input     string
-		string    string
-		cloud     names.CloudTag
-		owner     names.UserTag
-		name      string
-		canonical string
+		input  string
+		string string
+		cloud  names.CloudTag
+		owner  names.UserTag
+		name   string
 	}{
 		{
-			input:     "aws/bob/foo",
-			canonical: "aws/bob@local/foo",
-			string:    "cloudcred-aws_bob_foo",
-			cloud:     names.NewCloudTag("aws"),
-			owner:     names.NewUserTag("bob"),
-			name:      "foo",
+			input:  "aws/bob/foo",
+			string: "cloudcred-aws_bob_foo",
+			cloud:  names.NewCloudTag("aws"),
+			owner:  names.NewUserTag("bob"),
+			name:   "foo",
 		}, {
-			input:     "aws/bob@remote/foo",
-			canonical: "aws/bob@remote/foo",
-			string:    "cloudcred-aws_bob@remote_foo",
-			cloud:     names.NewCloudTag("aws"),
-			owner:     names.NewUserTag("bob@remote"),
-			name:      "foo",
+			input:  "aws/bob@remote/foo",
+			string: "cloudcred-aws_bob@remote_foo",
+			cloud:  names.NewCloudTag("aws"),
+			owner:  names.NewUserTag("bob@remote"),
+			name:   "foo",
 		}, {
-			input:     "aws/bob@remote/foo@somewhere.com",
-			canonical: "aws/bob@remote/foo@somewhere.com",
-			string:    "cloudcred-aws_bob@remote_foo@somewhere.com",
-			cloud:     names.NewCloudTag("aws"),
-			owner:     names.NewUserTag("bob@remote"),
-			name:      "foo@somewhere.com",
+			input:  "aws/bob@remote/foo@somewhere.com",
+			string: "cloudcred-aws_bob@remote_foo@somewhere.com",
+			cloud:  names.NewCloudTag("aws"),
+			owner:  names.NewUserTag("bob@remote"),
+			name:   "foo@somewhere.com",
 		}, {
-			input:     "aws/bob@remote/foo_bar",
-			canonical: "aws/bob@remote/foo_bar",
-			string:    `cloudcred-aws_bob@remote_foo%5fbar`,
-			cloud:     names.NewCloudTag("aws"),
-			owner:     names.NewUserTag("bob@remote"),
-			name:      "foo_bar",
+			input:  "aws/bob@remote/foo_bar",
+			string: `cloudcred-aws_bob@remote_foo%5fbar`,
+			cloud:  names.NewCloudTag("aws"),
+			owner:  names.NewUserTag("bob@remote"),
+			name:   "foo_bar",
 		},
 	} {
 		c.Logf("test %d: %s", i, t.input)
@@ -59,7 +54,6 @@ func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
 		c.Check(cloudTag.Cloud(), gc.Equals, t.cloud)
 		c.Check(cloudTag.Owner(), gc.Equals, t.owner)
 		c.Check(cloudTag.Name(), gc.Equals, t.name)
-		c.Check(cloudTag.Canonical(), gc.Equals, t.canonical)
 	}
 }
 

--- a/equality_test.go
+++ b/equality_test.go
@@ -19,7 +19,7 @@ var tagEqualityTests = []struct {
 	{NewRelationTag("wordpress:haproxy"), RelationTag{key: "wordpress.haproxy"}},
 	{NewEnvironTag("deadbeef-0123-4567-89ab-feedfacebeef"), EnvironTag{uuid: "deadbeef-0123-4567-89ab-feedfacebeef"}},
 	{NewUserTag("admin"), UserTag{name: "admin"}},
-	{NewUserTag("admin@local"), UserTag{name: "admin", domain: "local"}},
+	{NewUserTag("admin@local"), UserTag{name: "admin", domain: ""}},
 	{NewUserTag("admin@foobar"), UserTag{name: "admin", domain: "foobar"}},
 	{NewActionTag("01234567-aaaa-4bbb-8ccc-012345678901"), ActionTag{ID: stringToUUID("01234567-aaaa-4bbb-8ccc-012345678901")}},
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -143,10 +143,10 @@ var parseTagTests = []struct {
 	expectType: names.UserTag{},
 	resultId:   "foo",
 }, {
-	tag:        "user-foo@local",
+	tag:        "user-foo@remote",
 	expectKind: names.UserTagKind,
 	expectType: names.UserTag{},
-	resultId:   "foo@local",
+	resultId:   "foo@remote",
 }, {
 	tag:        "user-/",
 	expectKind: names.UserTagKind,

--- a/user_test.go
+++ b/user_test.go
@@ -27,14 +27,12 @@ func (s *userSuite) TestUserTag(c *gc.C) {
 			input:    "bob",
 			string:   "user-bob",
 			name:     "bob",
-			domain:   names.LocalUserDomain,
-			username: "bob@local",
+			username: "bob",
 		}, {
 			input:    "bob@local",
-			string:   "user-bob@local",
+			string:   "user-bob",
 			name:     "bob",
-			domain:   names.LocalUserDomain,
-			username: "bob@local",
+			username: "bob",
 		}, {
 			input:    "bob@foo",
 			string:   "user-bob@foo",
@@ -46,11 +44,10 @@ func (s *userSuite) TestUserTag(c *gc.C) {
 		c.Logf("test %d: %s", i, t.input)
 		userTag := names.NewUserTag(t.input)
 		c.Check(userTag.String(), gc.Equals, t.string)
-		c.Check(userTag.Id(), gc.Equals, t.input)
+		c.Check(userTag.Id(), gc.Equals, t.username)
 		c.Check(userTag.Name(), gc.Equals, t.name)
 		c.Check(userTag.Domain(), gc.Equals, t.domain)
-		c.Check(userTag.IsLocal(), gc.Equals, t.domain == names.LocalUserDomain)
-		c.Check(userTag.Canonical(), gc.Equals, t.username)
+		c.Check(userTag.IsLocal(), gc.Equals, t.domain == "")
 	}
 }
 
@@ -61,7 +58,7 @@ var withDomainTests = []struct {
 }{{
 	id:       "bob",
 	domain:   names.LocalUserDomain,
-	expectId: "bob@local",
+	expectId: "bob",
 }, {
 	id:       "bob@local",
 	domain:   "foo",
@@ -72,7 +69,7 @@ var withDomainTests = []struct {
 }, {
 	id:       "bob@foo",
 	domain:   names.LocalUserDomain,
-	expectId: "bob@local",
+	expectId: "bob",
 }, {
 	id:     "bob",
 	domain: "@foo",
@@ -229,11 +226,10 @@ func (s *userSuite) TestParseUserTag(c *gc.C) {
 
 func (s *userSuite) TestNewLocalUserTag(c *gc.C) {
 	user := names.NewLocalUserTag("bob")
-	c.Assert(user.Canonical(), gc.Equals, "bob@local")
 	c.Assert(user.Name(), gc.Equals, "bob")
-	c.Assert(user.Domain(), gc.Equals, "local")
+	c.Assert(user.Domain(), gc.Equals, "")
 	c.Assert(user.IsLocal(), gc.Equals, true)
-	c.Assert(user.String(), gc.Equals, "user-bob@local")
+	c.Assert(user.String(), gc.Equals, "user-bob")
 
 	c.Assert(func() { names.NewLocalUserTag("bob@local") }, gc.PanicMatches, `invalid user name "bob@local"`)
 	c.Assert(func() { names.NewLocalUserTag("") }, gc.PanicMatches, `invalid user name ""`)


### PR DESCRIPTION
Local users either have an empty domain or a "@local" domain. In either case, the user Id() will now simply be the user name (with no domain suffix). This means that the Canonical() method is no longer required.
