### PR TITLE
make CloudCredential Id and String work better on empty cloud credentials

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -30,11 +30,20 @@ type CloudCredentialTag struct {
 	name  string
 }
 
+// IsZero reports whether t is zero.
+func (t CloudCredentialTag) IsZero() bool {
+	return t == CloudCredentialTag{}
+}
+
 // Kind is part of the Tag interface.
 func (t CloudCredentialTag) Kind() string { return CloudCredentialTagKind }
 
-// Id is part of the Tag interface.
+// Id implements Tag.Id. It returns the empty string
+// if t is zero.
 func (t CloudCredentialTag) Id() string {
+	if t.IsZero() {
+		return ""
+	}
 	return fmt.Sprintf("%s/%s/%s", t.cloud.Id(), t.owner.Id(), t.name)
 }
 
@@ -42,8 +51,12 @@ func quoteCredentialSeparator(in string) string {
 	return strings.Replace(in, "_", `%5f`, -1)
 }
 
-// String is part of the Tag interface.
+// String implements Tag.String. It returns the empty
+// string if t is zero.
 func (t CloudCredentialTag) String() string {
+	if t.IsZero() {
+		return ""
+	}
 	return fmt.Sprintf("%s-%s_%s_%s", t.Kind(),
 		quoteCredentialSeparator(t.cloud.Id()),
 		quoteCredentialSeparator(t.owner.Id()),

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -130,3 +130,16 @@ func (s *cloudCredentialSuite) TestParseCloudCredentialTag(c *gc.C) {
 		c.Check(got, gc.Equals, t.expected)
 	}
 }
+
+func (s *cloudCredentialSuite) TestIsZero(c *gc.C) {
+	c.Assert(names.CloudCredentialTag{}.IsZero(), gc.Equals, true)
+	c.Assert(names.NewCloudCredentialTag("aws/bob/foo").IsZero(), gc.Equals, false)
+}
+
+func (s *cloudCredentialSuite) TestZeroString(c *gc.C) {
+	c.Assert(names.CloudCredentialTag{}.String(), gc.Equals, "")
+}
+
+func (s *cloudCredentialSuite) TestZeroId(c *gc.C) {
+	c.Assert(names.CloudCredentialTag{}.Id(), gc.Equals, "")
+}


### PR DESCRIPTION
Various pieces of code explicitly check for an empty cloud credential
and use an empty string for the tag if so.
This PR makes that behaviour easier to obtain.