### PR TITLE
Add + as valid part of cloud credential name.

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -13,7 +13,7 @@ import (
 const CloudCredentialTagKind = "cloudcred"
 
 var (
-	cloudCredentialNameSnippet = "[a-zA-Z][a-zA-Z0-9.@_-]*"
+	cloudCredentialNameSnippet = "[a-zA-Z][a-zA-Z0-9.@_+-]*"
 	validCloudCredentialName   = regexp.MustCompile("^" + cloudCredentialNameSnippet + "$")
 	validCloudCredential       = regexp.MustCompile(
 		"^" +

--- a/cloudcredential_test.go
+++ b/cloudcredential_test.go
@@ -45,6 +45,12 @@ func (s *cloudCredentialSuite) TestCloudCredentialTag(c *gc.C) {
 			cloud:  names.NewCloudTag("aws"),
 			owner:  names.NewUserTag("bob@remote"),
 			name:   "foo_bar",
+		}, {
+			input:  "google/bob+bob@remote/foo_bar",
+			string: `cloudcred-google_bob+bob@remote_foo%5fbar`,
+			cloud:  names.NewCloudTag("google"),
+			owner:  names.NewUserTag("bob+bob@remote"),
+			name:   "foo_bar",
 		},
 	} {
 		c.Logf("test %d: %s", i, t.input)
@@ -65,6 +71,7 @@ func (s *cloudCredentialSuite) TestIsValidCloudCredential(c *gc.C) {
 		{"", false},
 		{"aws/bob/foo", true},
 		{"aws/bob@local/foo", true},
+		{"google/bob+bob@local/foo", true},
 		{"/bob/foo", false},
 		{"aws//foo", false},
 		{"aws/bob/", false},
@@ -84,6 +91,7 @@ func (s *cloudCredentialSuite) TestIsValidCloudCredentialName(c *gc.C) {
 		{"f00b4r", true},
 		{"foo-bar", true},
 		{"foo@bar", true},
+		{"foo+foo@bar", true},
 		{"foo_bar", true},
 		{"123", false},
 		{"0foo", false},


### PR DESCRIPTION
As per https://bugs.launchpad.net/juju/+bug/1671915, adding ability to have a + in cloud credential name.