### PR TITLE
Be able to get the parent machine from a container machine tag.

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -36,6 +36,16 @@ func (t MachineTag) String() string { return t.Kind() + "-" + t.id }
 func (t MachineTag) Kind() string   { return MachineTagKind }
 func (t MachineTag) Id() string     { return machineTagSuffixToId(t.id) }
 
+// Parent returns the machineTag for the host of the container if the machineTag
+// is a container, otherwise it returns nil.
+func (t MachineTag) Parent() Tag {
+	parts := strings.Split(t.id, "-")
+	if len(parts) < 3 {
+		return nil
+	}
+	return MachineTag{id: strings.Join(parts[:len(parts)-2], "-")}
+}
+
 // NewMachineTag returns the tag for the machine with the given id.
 func NewMachineTag(id string) MachineTag {
 	id = strings.Replace(id, "/", "-", -1)

--- a/machine_test.go
+++ b/machine_test.go
@@ -29,6 +29,7 @@ var machineIdTests = []struct {
 	pattern   string
 	valid     bool
 	container bool
+	parent    names.Tag
 }{
 	{pattern: "42", valid: true},
 	{pattern: "042", valid: false},
@@ -38,7 +39,7 @@ var machineIdTests = []struct {
 	{pattern: "55/", valid: false},
 	{pattern: "1/foo", valid: false},
 	{pattern: "2/foo/", valid: false},
-	{pattern: "3/lxc/42", valid: true, container: true},
+	{pattern: "3/lxc/42", valid: true, container: true, parent: names.NewMachineTag("3")},
 	{pattern: "3/lxc-nodash/42", valid: false},
 	{pattern: "0/lxc/00", valid: false},
 	{pattern: "0/lxc/0/", valid: false},
@@ -46,7 +47,7 @@ var machineIdTests = []struct {
 	{pattern: "3/lxc/042", valid: false},
 	{pattern: "4/foo/bar", valid: false},
 	{pattern: "5/lxc/42/foo", valid: false},
-	{pattern: "6/lxc/42/kvm/0", valid: true, container: true},
+	{pattern: "6/lxc/42/kvm/0", valid: true, container: true, parent: names.NewMachineTag("6/lxc/42")},
 	{pattern: "06/lxc/42/kvm/0", valid: false},
 	{pattern: "6/lxc/042/kvm/0", valid: false},
 	{pattern: "6/lxc/42/kvm/00", valid: false},
@@ -56,8 +57,12 @@ var machineIdTests = []struct {
 func (s *machineSuite) TestMachineIdFormats(c *gc.C) {
 	for i, test := range machineIdTests {
 		c.Logf("test %d: %q", i, test.pattern)
-		c.Assert(names.IsValidMachine(test.pattern), gc.Equals, test.valid)
-		c.Assert(names.IsContainerMachine(test.pattern), gc.Equals, test.container)
+		c.Check(names.IsValidMachine(test.pattern), gc.Equals, test.valid)
+		c.Check(names.IsContainerMachine(test.pattern), gc.Equals, test.container)
+		if test.valid {
+			machine := names.NewMachineTag(test.pattern)
+			c.Check(machine.Parent(), gc.Equals, test.parent)
+		}
 	}
 }
 


### PR DESCRIPTION
The names package already knows if something is a container, so why not have a machine tag able to return the Parent.