### PR TITLE
Add ChildId and ContainerType to MachineTag

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -57,6 +57,12 @@ func (t MachineTag) ContainerType() string {
 	return parts[size-2]
 }
 
+// ChildId returns just the last segment of the ID.
+func (t MachineTag) ChildId() string {
+	parts := strings.Split(t.id, "-")
+	return parts[len(parts)-1]
+}
+
 // NewMachineTag returns the tag for the machine with the given id.
 func NewMachineTag(id string) MachineTag {
 	id = strings.Replace(id, "/", "-", -1)

--- a/machine.go
+++ b/machine.go
@@ -46,6 +46,17 @@ func (t MachineTag) Parent() Tag {
 	return MachineTag{id: strings.Join(parts[:len(parts)-2], "-")}
 }
 
+// ContainerType returns the type of container for this machine.
+// If the machine isn't a container, then the empty string is returned.
+func (t MachineTag) ContainerType() string {
+	parts := strings.Split(t.id, "-")
+	size := len(parts)
+	if size < 3 {
+		return ""
+	}
+	return parts[size-2]
+}
+
 // NewMachineTag returns the tag for the machine with the given id.
 func NewMachineTag(id string) MachineTag {
 	id = strings.Replace(id, "/", "-", -1)

--- a/machine_test.go
+++ b/machine_test.go
@@ -31,16 +31,17 @@ var machineIdTests = []struct {
 	container     bool
 	parent        names.Tag
 	containerType string
+	childId       string
 }{
-	{pattern: "42", valid: true},
+	{pattern: "42", valid: true, childId: "42"},
 	{pattern: "042", valid: false},
-	{pattern: "0", valid: true},
+	{pattern: "0", valid: true, childId: "0"},
 	{pattern: "foo", valid: false},
 	{pattern: "/", valid: false},
 	{pattern: "55/", valid: false},
 	{pattern: "1/foo", valid: false},
 	{pattern: "2/foo/", valid: false},
-	{pattern: "3/lxc/42", valid: true, container: true, parent: names.NewMachineTag("3"), containerType: "lxc"},
+	{pattern: "3/lxc/42", valid: true, container: true, parent: names.NewMachineTag("3"), containerType: "lxc", childId: "42"},
 	{pattern: "3/lxc-nodash/42", valid: false},
 	{pattern: "0/lxc/00", valid: false},
 	{pattern: "0/lxc/0/", valid: false},
@@ -48,7 +49,7 @@ var machineIdTests = []struct {
 	{pattern: "3/lxc/042", valid: false},
 	{pattern: "4/foo/bar", valid: false},
 	{pattern: "5/lxc/42/foo", valid: false},
-	{pattern: "6/lxc/42/kvm/0", valid: true, container: true, parent: names.NewMachineTag("6/lxc/42"), containerType: "kvm"},
+	{pattern: "6/lxc/42/kvm/0", valid: true, container: true, parent: names.NewMachineTag("6/lxc/42"), containerType: "kvm", childId: "0"},
 	{pattern: "06/lxc/42/kvm/0", valid: false},
 	{pattern: "6/lxc/042/kvm/0", valid: false},
 	{pattern: "6/lxc/42/kvm/00", valid: false},
@@ -64,6 +65,7 @@ func (s *machineSuite) TestMachineIdFormats(c *gc.C) {
 			machine := names.NewMachineTag(test.pattern)
 			c.Check(machine.Parent(), gc.Equals, test.parent)
 			c.Check(machine.ContainerType(), gc.Equals, test.containerType)
+			c.Check(machine.ChildId(), gc.Equals, test.childId)
 		}
 	}
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -26,10 +26,11 @@ func (s *machineSuite) TestMachineTag(c *gc.C) {
 }
 
 var machineIdTests = []struct {
-	pattern   string
-	valid     bool
-	container bool
-	parent    names.Tag
+	pattern       string
+	valid         bool
+	container     bool
+	parent        names.Tag
+	containerType string
 }{
 	{pattern: "42", valid: true},
 	{pattern: "042", valid: false},
@@ -39,7 +40,7 @@ var machineIdTests = []struct {
 	{pattern: "55/", valid: false},
 	{pattern: "1/foo", valid: false},
 	{pattern: "2/foo/", valid: false},
-	{pattern: "3/lxc/42", valid: true, container: true, parent: names.NewMachineTag("3")},
+	{pattern: "3/lxc/42", valid: true, container: true, parent: names.NewMachineTag("3"), containerType: "lxc"},
 	{pattern: "3/lxc-nodash/42", valid: false},
 	{pattern: "0/lxc/00", valid: false},
 	{pattern: "0/lxc/0/", valid: false},
@@ -47,7 +48,7 @@ var machineIdTests = []struct {
 	{pattern: "3/lxc/042", valid: false},
 	{pattern: "4/foo/bar", valid: false},
 	{pattern: "5/lxc/42/foo", valid: false},
-	{pattern: "6/lxc/42/kvm/0", valid: true, container: true, parent: names.NewMachineTag("6/lxc/42")},
+	{pattern: "6/lxc/42/kvm/0", valid: true, container: true, parent: names.NewMachineTag("6/lxc/42"), containerType: "kvm"},
 	{pattern: "06/lxc/42/kvm/0", valid: false},
 	{pattern: "6/lxc/042/kvm/0", valid: false},
 	{pattern: "6/lxc/42/kvm/00", valid: false},
@@ -62,6 +63,7 @@ func (s *machineSuite) TestMachineIdFormats(c *gc.C) {
 		if test.valid {
 			machine := names.NewMachineTag(test.pattern)
 			c.Check(machine.Parent(), gc.Equals, test.parent)
+			c.Check(machine.ContainerType(), gc.Equals, test.containerType)
 		}
 	}
 }


### PR DESCRIPTION
The machine tag knows about container types and the number of the container, so add methods to return these from the tag.