### PR TITLE
Be able to get unit number out of a UnitTag.

### DIFF
--- a/unit.go
+++ b/unit.go
@@ -6,6 +6,7 @@ package names
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -20,6 +21,16 @@ type UnitTag struct {
 func (t UnitTag) String() string { return t.Kind() + "-" + t.name }
 func (t UnitTag) Kind() string   { return UnitTagKind }
 func (t UnitTag) Id() string     { return unitTagSuffixToId(t.name) }
+
+// Number returns the unit number from the tag, effectively the NumberSnippet from the
+// validUnit regular expression.
+func (t UnitTag) Number() int {
+	if i := strings.LastIndex(t.name, "-"); i > 0 {
+		num, _ := strconv.Atoi(t.name[i+1:])
+		return num
+	}
+	return 0
+}
 
 // NewUnitTag returns the tag for the unit with the given name.
 // It will panic if the given unit name is not valid.

--- a/unit_test.go
+++ b/unit_test.go
@@ -54,6 +54,13 @@ func (s *unitSuite) TestInvalidUnitTagFormats(c *gc.C) {
 	}
 }
 
+func (s *unitSuite) TestNumber(c *gc.C) {
+	u := names.UnitTag{}
+	c.Assert(u.Number(), gc.Equals, 0)
+	u = names.NewUnitTag("foo-t4/5")
+	c.Assert(u.Number(), gc.Equals, 5)
+}
+
 func (s *applicationSuite) TestUnitApplication(c *gc.C) {
 	for i, test := range unitNameTests {
 		c.Logf("test %d: %q", i, test.pattern)


### PR DESCRIPTION
In order to be able to infer application sequence numbers when not provided, the tag can now return the unit number.