### PR TITLE
Set max application name length to 48 chars

### DIFF
--- a/application.go
+++ b/application.go
@@ -15,10 +15,11 @@ const (
 )
 
 var validApplication = regexp.MustCompile("^" + ApplicationSnippet + "$")
+var maxApplicationLength = 48
 
 // IsValidApplication returns whether name is a valid application name.
 func IsValidApplication(name string) bool {
-	return validApplication.MatchString(name)
+	return validApplication.MatchString(name) && len(name) <= maxApplicationLength
 }
 
 type ApplicationTag struct {


### PR DESCRIPTION
Application name is used in some places where the length must be limited (eg. http://pad.lv/1731027), this limits the length of the application name to 48 chars - this ought to be enough for anybody. 