### PR TITLE
Add the set type from utils/set.

### DIFF
--- a/set.go
+++ b/set.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2014-2018 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package names

--- a/set.go
+++ b/set.go
@@ -1,0 +1,148 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names
+
+import (
+	"sort"
+
+	"github.com/juju/errors"
+)
+
+// Set represents the Set data structure, and contains Tags.
+type Set map[Tag]bool
+
+// NewSet creates and initializes a Set and populates it with
+// inital values as specified in the parameters.
+func NewSet(initial ...Tag) Set {
+	result := make(Set)
+	for _, value := range initial {
+		result.Add(value)
+	}
+	return result
+}
+
+// NewSetFromStrings creates and initializes a Set and populates it
+// by using names.ParseTag on the initial values specified in the parameters.
+func NewSetFromStrings(initial ...string) (Set, error) {
+	result := make(Set)
+	for _, value := range initial {
+		tag, err := ParseTag(value)
+		if err != nil {
+			return result, errors.Trace(err)
+		}
+		result.Add(tag)
+	}
+	return result, nil
+}
+
+// Size returns the number of elements in the set.
+func (t Set) Size() int {
+	return len(t)
+}
+
+// IsEmpty is true for empty or uninitialized sets.
+func (t Set) IsEmpty() bool {
+	return len(t) == 0
+}
+
+// Add puts a value into the set.
+func (t Set) Add(value Tag) {
+	if t == nil {
+		panic("uninitalised set")
+	}
+	t[value] = true
+}
+
+// Remove takes a value out of the set.  If value wasn't in the set to start
+// with, this method silently succeeds.
+func (t Set) Remove(value Tag) {
+	delete(t, value)
+}
+
+// Contains returns true if the value is in the set, and false otherwise.
+func (t Set) Contains(value Tag) bool {
+	_, exists := t[value]
+	return exists
+}
+
+// Values returns an unordered slice containing all the values in the set.
+func (t Set) Values() []Tag {
+	result := make([]Tag, len(t))
+	i := 0
+	for key := range t {
+		result[i] = key
+		i++
+	}
+	return result
+}
+
+// stringValues returns a list of strings that represent a Tag.
+// Used internally by the SortedValues method.
+func (t Set) stringValues() []string {
+	result := make([]string, t.Size())
+	i := 0
+	for key := range t {
+		result[i] = key.String()
+		i++
+	}
+	return result
+}
+
+// SortedValues returns an ordered slice containing all the values in the set.
+func (t Set) SortedValues() []Tag {
+	values := t.stringValues()
+	sort.Strings(values)
+
+	result := make([]Tag, len(values))
+	for i, value := range values {
+		// We already know only good strings can live in the Tags set
+		// so we can safely ignore the error here.
+		tag, _ := ParseTag(value)
+		result[i] = tag
+	}
+	return result
+}
+
+// Union returns a new Set representing a union of the elments in the
+// method target and the parameter.
+func (t Set) Union(other Set) Set {
+	result := make(Set)
+	// Use the internal map rather than going through the friendlier functions
+	// to avoid extra allocation of slices.
+	for value := range t {
+		result[value] = true
+	}
+	for value := range other {
+		result[value] = true
+	}
+	return result
+}
+
+// Intersection returns a new Set representing a intersection of the elments in the
+// method target and the parameter.
+func (t Set) Intersection(other Set) Set {
+	result := make(Set)
+	// Use the internal map rather than going through the friendlier functions
+	// to avoid extra allocation of slices.
+	for value := range t {
+		if other.Contains(value) {
+			result[value] = true
+		}
+	}
+	return result
+}
+
+// Difference returns a new Tags representing all the values in the
+// target that are not in the parameter.
+func (t Set) Difference(other Set) Set {
+	result := make(Set)
+	// Use the internal map rather than going through the friendlier functions
+	// to avoid extra allocation of slices.
+	for value := range t {
+		if !other.Contains(value) {
+			result[value] = true
+		}
+	}
+	return result
+}

--- a/set_test.go
+++ b/set_test.go
@@ -1,4 +1,4 @@
-// Copyright 2013 Canonical Ltd.
+// Copyright 2013-2018 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 package names_test
@@ -53,6 +53,11 @@ func (tagSetSuite) TestInitialStringValues(c *gc.C) {
 	t, err := names.NewSetFromStrings("unit-wordpress-0", "unit-rabbitmq-server-0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(t.Size(), gc.Equals, 2)
+}
+
+func (tagSetSuite) TestInitialStringValuesBad(c *gc.C) {
+	_, err := names.NewSetFromStrings("not-a-tag")
+	c.Assert(err, gc.ErrorMatches, `"not-a-tag" is not a valid tag`)
 }
 
 func (tagSetSuite) TestSize(c *gc.C) {

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,191 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package names_test
+
+import (
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/names.v2"
+)
+
+type tagSetSuite struct {
+	testing.IsolationSuite
+
+	foo  names.Tag
+	bar  names.Tag
+	baz  names.Tag
+	bang names.Tag
+}
+
+var _ = gc.Suite(&tagSetSuite{})
+
+func (s *tagSetSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+
+	var err error
+
+	s.foo, err = names.ParseTag("unit-wordpress-0")
+	c.Assert(err, gc.IsNil)
+
+	s.bar, err = names.ParseTag("unit-rabbitmq-server-0")
+	c.Assert(err, gc.IsNil)
+
+	s.baz, err = names.ParseTag("unit-mongodb-0")
+	c.Assert(err, gc.IsNil)
+
+	s.bang, err = names.ParseTag("machine-0")
+	c.Assert(err, gc.IsNil)
+}
+
+func (tagSetSuite) TestEmpty(c *gc.C) {
+	t := names.NewSet()
+	c.Assert(t.Size(), gc.Equals, 0)
+}
+
+func (s tagSetSuite) TestInitialValues(c *gc.C) {
+	t := names.NewSet(s.foo, s.bar)
+	c.Assert(t.Size(), gc.Equals, 2)
+}
+
+func (tagSetSuite) TestInitialStringValues(c *gc.C) {
+	t, err := names.NewSetFromStrings("unit-wordpress-0", "unit-rabbitmq-server-0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(t.Size(), gc.Equals, 2)
+}
+
+func (tagSetSuite) TestSize(c *gc.C) {
+	// Empty sets are empty.
+	s := names.NewSet()
+	c.Assert(s.Size(), gc.Equals, 0)
+
+	s, err := names.NewSetFromStrings(
+		"unit-wordpress-0",
+		"unit-rabbitmq-server-0",
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.Size(), gc.Equals, 2)
+}
+
+func (tagSetSuite) TestSizeDuplicate(c *gc.C) {
+	// Empty sets are empty.
+	s := names.NewSet()
+	c.Assert(s.Size(), gc.Equals, 0)
+
+	// Size returns number of unique values.
+	s, err := names.NewSetFromStrings(
+		"unit-wordpress-0",
+		"unit-rabbitmq-server-0",
+		"unit-wordpress-0",
+	)
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.Size(), gc.Equals, 2)
+}
+
+func (s tagSetSuite) TestIsEmpty(c *gc.C) {
+	// Empty sets are empty.
+	t := names.NewSet()
+	c.Assert(t.IsEmpty(), gc.Equals, true)
+
+	// Non-empty sets are not empty.
+	t = names.NewSet(s.foo)
+	c.Assert(t.IsEmpty(), gc.Equals, false)
+
+	// Newly empty sets work too.
+	t.Remove(s.foo)
+	c.Assert(t.IsEmpty(), gc.Equals, true)
+}
+
+func (s tagSetSuite) TestAdd(c *gc.C) {
+	t := names.NewSet()
+	t.Add(s.foo)
+	c.Assert(t.Size(), gc.Equals, 1)
+	c.Assert(t.Contains(s.foo), gc.Equals, true)
+}
+
+func (s tagSetSuite) TestAddDuplicate(c *gc.C) {
+	t := names.NewSet()
+
+	t.Add(s.foo)
+	t.Add(s.bar)
+	t.Add(s.bar)
+
+	c.Assert(t.Size(), gc.Equals, 2)
+}
+
+func (s tagSetSuite) TestRemove(c *gc.C) {
+	t := names.NewSet(s.foo, s.bar)
+	t.Remove(s.foo)
+
+	c.Assert(t.Contains(s.foo), gc.Equals, false)
+	c.Assert(t.Contains(s.bar), gc.Equals, true)
+}
+
+func (s tagSetSuite) TestContains(c *gc.C) {
+	t, err := names.NewSetFromStrings("unit-wordpress-0", "unit-rabbitmq-server-0")
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(t.Contains(s.foo), gc.Equals, true)
+	c.Assert(t.Contains(s.bar), gc.Equals, true)
+	c.Assert(t.Contains(s.baz), gc.Equals, false)
+}
+
+func (s tagSetSuite) TestSortedValues(c *gc.C) {
+	t := names.NewSet(s.foo, s.bang, s.baz, s.bar)
+	values := t.SortedValues()
+
+	c.Assert(values, gc.DeepEquals, []names.Tag{s.bang, s.baz, s.bar, s.foo})
+}
+
+func (s tagSetSuite) TestRemoveNonExistent(c *gc.C) {
+	t := names.NewSet()
+	t.Remove(s.foo)
+	c.Assert(t.Size(), gc.Equals, 0)
+}
+
+func (s tagSetSuite) TestUnion(c *gc.C) {
+	t1 := names.NewSet(s.foo, s.bar)
+	t2 := names.NewSet(s.foo, s.baz, s.bang)
+	union1 := t1.Union(t2)
+	union2 := t2.Union(t1)
+
+	c.Assert(union1.Size(), gc.Equals, 4)
+	c.Assert(union2.Size(), gc.Equals, 4)
+
+	c.Assert(union1, gc.DeepEquals, union2)
+	c.Assert(union1, gc.DeepEquals, names.NewSet(s.foo, s.bar, s.baz, s.bang))
+}
+
+func (s tagSetSuite) TestIntersection(c *gc.C) {
+	t1 := names.NewSet(s.foo, s.bar)
+	t2 := names.NewSet(s.foo, s.baz, s.bang)
+
+	int1 := t1.Intersection(t2)
+	int2 := t2.Intersection(t1)
+
+	c.Assert(int1.Size(), gc.Equals, 1)
+	c.Assert(int2.Size(), gc.Equals, 1)
+
+	c.Assert(int1, gc.DeepEquals, int2)
+	c.Assert(int1, gc.DeepEquals, names.NewSet(s.foo))
+}
+
+func (s tagSetSuite) TestDifference(c *gc.C) {
+	t1 := names.NewSet(s.foo, s.bar)
+	t2 := names.NewSet(s.foo, s.baz, s.bang)
+
+	diff1 := t1.Difference(t2)
+	diff2 := t2.Difference(t1)
+
+	c.Assert(diff1, gc.DeepEquals, names.NewSet(s.bar))
+	c.Assert(diff2, gc.DeepEquals, names.NewSet(s.baz, s.bang))
+}
+
+func (s tagSetSuite) TestUninitializedPanics(c *gc.C) {
+	f := func() {
+		var t names.Set
+		t.Add(s.foo)
+	}
+	c.Assert(f, gc.PanicMatches, "uninitalised set")
+}


### PR DESCRIPTION
As part of the change, we now have names.Set and names.NewSet, rather than the old set.Tags and set.NewTags.