### PR TITLE
Filesystems and volumes can be attached to units

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -11,9 +11,9 @@ import (
 
 const FilesystemTagKind = "filesystem"
 
-// Filesystems may be bound to a machine, meaning that the filesystem cannot
-// exist without that machine. We encode this in the tag.
-var validFilesystem = regexp.MustCompile("^(" + MachineSnippet + "/)?" + NumberSnippet + "$")
+// Filesystems may be bound to a machine or unit, meaning that the filesystem cannot
+// exist without that machine or unit. We encode this in the tag.
+var validFilesystem = regexp.MustCompile("^((" + MachineSnippet + "|" + UnitSnippet + ")/)?" + NumberSnippet + "$")
 
 type FilesystemTag struct {
 	id string
@@ -60,7 +60,27 @@ func FilesystemMachine(tag FilesystemTag) (MachineTag, bool) {
 	if pos == -1 {
 		return MachineTag{}, false
 	}
-	return NewMachineTag(id[:pos]), true
+	id = id[:pos]
+	if !IsValidMachine(id) {
+		return MachineTag{}, false
+	}
+	return NewMachineTag(id), true
+}
+
+// FilesystemUnit returns the unit component of the filesystem
+// tag, and a boolean indicating whether or not there is a
+// unit component.
+func FilesystemUnit(tag FilesystemTag) (UnitTag, bool) {
+	id := tag.Id()
+	pos := strings.LastIndex(id, "/")
+	if pos == -1 {
+		return UnitTag{}, false
+	}
+	id = id[:pos]
+	if !IsValidUnit(id) {
+		return UnitTag{}, false
+	}
+	return NewUnitTag(id[:pos]), true
 }
 
 func tagFromFilesystemId(id string) (FilesystemTag, bool) {
@@ -71,6 +91,18 @@ func tagFromFilesystemId(id string) (FilesystemTag, bool) {
 	return FilesystemTag{id}, true
 }
 
+var validMachineSuffix = regexp.MustCompile("^(" + MachineSnippet + "-).*")
+
 func filesystemTagSuffixToId(s string) string {
-	return strings.Replace(s, "-", "/", -1)
+	if validMachineSuffix.MatchString(s) {
+		return strings.Replace(s, "-", "/", -1)
+	}
+	// Replace only the last 2 "-" with "/", as it is valid for unit
+	// names to contain hyphens
+	for x := 0; x < 2; x++ {
+		if i := strings.LastIndex(s, "-"); i > 0 {
+			s = s[:i] + "/" + s[i+1:]
+		}
+	}
+	return s
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -21,7 +21,7 @@ type FilesystemTag struct {
 
 func (t FilesystemTag) String() string { return t.Kind() + "-" + t.id }
 func (t FilesystemTag) Kind() string   { return FilesystemTagKind }
-func (t FilesystemTag) Id() string     { return filesystemTagSuffixToId(t.id) }
+func (t FilesystemTag) Id() string     { return filesystemOrVolumeTagSuffixToId(t.id) }
 
 // NewFilesystemTag returns the tag for the filesystem with the given name.
 // It will panic if the given filesystem name is not valid.
@@ -93,7 +93,7 @@ func tagFromFilesystemId(id string) (FilesystemTag, bool) {
 
 var validMachineSuffix = regexp.MustCompile("^(" + MachineSnippet + "-).*")
 
-func filesystemTagSuffixToId(s string) string {
+func filesystemOrVolumeTagSuffixToId(s string) string {
 	if validMachineSuffix.MatchString(s) {
 		return strings.Replace(s, "-", "/", -1)
 	}

--- a/tag.go
+++ b/tag.go
@@ -140,7 +140,7 @@ func ParseTag(tag string) (Tag, error) {
 		}
 		return NewActionTag(id), nil
 	case VolumeTagKind:
-		id = volumeTagSuffixToId(id)
+		id = filesystemOrVolumeTagSuffixToId(id)
 		if !IsValidVolume(id) {
 			return nil, invalidTagError(tag, kind)
 		}
@@ -157,7 +157,7 @@ func ParseTag(tag string) (Tag, error) {
 		}
 		return NewStorageTag(id), nil
 	case FilesystemTagKind:
-		id = filesystemTagSuffixToId(id)
+		id = filesystemOrVolumeTagSuffixToId(id)
 		if !IsValidFilesystem(id) {
 			return nil, invalidTagError(tag, kind)
 		}

--- a/unit.go
+++ b/unit.go
@@ -17,7 +17,10 @@ const UnitTagKind = "unit"
 // on that value so change it carefully.
 const minShortenedLength = 21
 
-var validUnit = regexp.MustCompile("^(" + ApplicationSnippet + ")/" + NumberSnippet + "$")
+// UnitSnippet defines the regexp for a valid Unit Id.
+const UnitSnippet = "(" + ApplicationSnippet + ")/" + NumberSnippet
+
+var validUnit = regexp.MustCompile("^" + UnitSnippet + "$")
 
 type UnitTag struct {
 	name string

--- a/unit_test.go
+++ b/unit_test.go
@@ -17,6 +17,7 @@ var _ = gc.Suite(&unitSuite{})
 
 func (s *unitSuite) TestUnitTag(c *gc.C) {
 	c.Assert(names.NewUnitTag("wordpress/2").String(), gc.Equals, "unit-wordpress-2")
+	c.Assert(names.NewUnitTag("foo-bar/2").String(), gc.Equals, "unit-foo-bar-2")
 }
 
 var unitNameTests = []struct {
@@ -84,8 +85,11 @@ var parseUnitTagTests = []struct {
 	tag: "",
 	err: names.InvalidTagError("", ""),
 }, {
-	tag:      "unit-dave/0",
+	tag:      "unit-dave-0",
 	expected: names.NewUnitTag("dave/0"),
+}, {
+	tag:      "unit-foo-bar-0",
+	expected: names.NewUnitTag("foo-bar/0"),
 }, {
 	tag: "dave",
 	err: names.InvalidTagError("dave", ""),

--- a/volume.go
+++ b/volume.go
@@ -21,7 +21,7 @@ type VolumeTag struct {
 
 func (t VolumeTag) String() string { return t.Kind() + "-" + t.id }
 func (t VolumeTag) Kind() string   { return VolumeTagKind }
-func (t VolumeTag) Id() string     { return volumeTagSuffixToId(t.id) }
+func (t VolumeTag) Id() string     { return filesystemOrVolumeTagSuffixToId(t.id) }
 
 // NewVolumeTag returns the tag for the volume with the given ID.
 // It will panic if the given volume ID is not valid.
@@ -89,18 +89,4 @@ func tagFromVolumeId(id string) (VolumeTag, bool) {
 	}
 	id = strings.Replace(id, "/", "-", -1)
 	return VolumeTag{id}, true
-}
-
-func volumeTagSuffixToId(s string) string {
-	if validMachineSuffix.MatchString(s) {
-		return strings.Replace(s, "-", "/", -1)
-	}
-	// Replace only the last 2 "-" with "/", as it is valid for unit
-	// names to contain hyphens
-	for x := 0; x < 2; x++ {
-		if i := strings.LastIndex(s, "-"); i > 0 {
-			s = s[:i] + "/" + s[i+1:]
-		}
-	}
-	return s
 }


### PR DESCRIPTION
Filesystems and volumes can now be associated with units as well as machines.
As a driveby, fix some tests and add a couple more for unit tags.