### PR TITLE
Change NewCloudCredentialTag() to return an error for invalid IDs

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -81,14 +81,14 @@ func (t CloudCredentialTag) Name() string {
 
 // NewCloudCredentialTag returns the tag for the cloud with the given ID.
 // It will panic if the given cloud ID is not valid.
-func NewCloudCredentialTag(id string) CloudCredentialTag {
+func NewCloudCredentialTag(id string) (CloudCredentialTag, error) {
 	parts := validCloudCredential.FindStringSubmatch(id)
 	if len(parts) != 4 {
-		panic(fmt.Sprintf("%q is not a valid cloud credential ID", id))
+		return CloudCredentialTag{}, fmt.Errorf("%q is not a valid cloud credential ID", id)
 	}
 	cloud := NewCloudTag(parts[1])
 	owner := NewUserTag(parts[2])
-	return CloudCredentialTag{cloud, owner, parts[3]}
+	return CloudCredentialTag{cloud, owner, parts[3]}, nil
 }
 
 // ParseCloudCredentialTag parses a cloud tag string.

--- a/tag.go
+++ b/tag.go
@@ -196,7 +196,7 @@ func ParseTag(tag string) (Tag, error) {
 		if !IsValidCloudCredential(id) {
 			return nil, invalidTagError(tag, kind)
 		}
-		return NewCloudCredentialTag(id), nil
+		return NewCloudCredentialTag(id)
 	case CAASModelTagKind:
 		if !IsValidCAASModel(id) {
 			return nil, invalidTagError(tag, kind)

--- a/tag_test.go
+++ b/tag_test.go
@@ -265,8 +265,14 @@ var makeTag = map[string]func(string) names.Tag{
 	names.SubnetTagKind:           func(tag string) names.Tag { return names.NewSubnetTag(tag) },
 	names.SpaceTagKind:            func(tag string) names.Tag { return names.NewSpaceTag(tag) },
 	names.CloudTagKind:            func(tag string) names.Tag { return names.NewCloudTag(tag) },
-	names.CloudCredentialTagKind:  func(tag string) names.Tag { return names.NewCloudCredentialTag(tag) },
 	names.CAASModelTagKind:        func(tag string) names.Tag { return names.NewCAASModelTag(tag) },
+	names.CloudCredentialTagKind: func(tag string) names.Tag {
+		t, err := names.NewCloudCredentialTag(tag)
+		if err != nil {
+			panic(err)
+		}
+		return t
+	},
 }
 
 func (*tagSuite) TestParseTag(c *gc.C) {


### PR DESCRIPTION
The current implementation of `NewCloudCredentialTag` panics if an invalid ID (e.g one containing whitespace) is provided. This PR updates the function signature so an error can be returned instead.

This is part of the work required for fixing https://bugs.launchpad.net/juju/+bug/1702538