### PR TITLE
Give clouds minimum and maximum lengths

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -11,7 +11,7 @@ import (
 const CloudTagKind = "cloud"
 
 var (
-	cloudSnippet = "[a-zA-Z0-9][a-zA-Z0-9._-]*"
+	cloudSnippet = "[a-zA-Z0-9][a-zA-Z0-9._-]{1,4096}"
 	validCloud   = regexp.MustCompile("^" + cloudSnippet + "$")
 )
 

--- a/cloud.go
+++ b/cloud.go
@@ -11,7 +11,7 @@ import (
 const CloudTagKind = "cloud"
 
 var (
-	cloudSnippet = "[a-zA-Z0-9][a-zA-Z0-9._-]{1,4096}"
+	cloudSnippet = "[a-zA-Z0-9][a-zA-Z0-9._-]{0,200}"
 	validCloud   = regexp.MustCompile("^" + cloudSnippet + "$")
 )
 


### PR DESCRIPTION
This commit restricts the range of valid cloud names to [1, 4096]