### PR TITLE
SubnetTag is now an ID, not a CIDR.

### DIFF
--- a/subnet.go
+++ b/subnet.go
@@ -5,34 +5,32 @@ package names
 
 import (
 	"fmt"
-	"net"
+	"regexp"
 )
 
 const SubnetTagKind = "subnet"
 
-// IsValidSubnet returns whether cidr is a valid subnet CIDR.
-func IsValidSubnet(cidr string) bool {
-	_, ipNet, err := net.ParseCIDR(cidr)
-	if err == nil && ipNet.String() == cidr {
-		return true
-	}
-	return false
+var validSubnet = regexp.MustCompile("^" + NumberSnippet + "$")
+
+// IsValidSubnet returns whether id is a valid subnet id.
+func IsValidSubnet(id string) bool {
+	return validSubnet.MatchString(id)
 }
 
 type SubnetTag struct {
-	cidr string
+	id string
 }
 
-func (t SubnetTag) String() string { return t.Kind() + "-" + t.cidr }
+func (t SubnetTag) String() string { return t.Kind() + "-" + t.id }
 func (t SubnetTag) Kind() string   { return SubnetTagKind }
-func (t SubnetTag) Id() string     { return t.cidr }
+func (t SubnetTag) Id() string     { return t.id }
 
-// NewSubnetTag returns the tag for subnet with the given CIDR.
-func NewSubnetTag(cidr string) SubnetTag {
-	if !IsValidSubnet(cidr) {
-		panic(fmt.Sprintf("%s is not a valid subnet CIDR", cidr))
+// NewSubnetTag returns the tag for subnet with the given ID.
+func NewSubnetTag(id string) SubnetTag {
+	if !IsValidSubnet(id) {
+		panic(fmt.Sprintf("%s is not a valid subnet ID", id))
 	}
-	return SubnetTag{cidr: cidr}
+	return SubnetTag{id: id}
 }
 
 // ParseSubnetTag parses a subnet tag string.

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -14,18 +14,18 @@ type subnetSuite struct{}
 var _ = gc.Suite(&subnetSuite{})
 
 func (s *subnetSuite) TestNewSubnetTag(c *gc.C) {
-	cidr := "10.20.0.0/16"
-	tag := names.NewSubnetTag(cidr)
+	id := "16"
+	tag := names.NewSubnetTag(id)
 	parsed, err := names.ParseSubnetTag(tag.String())
 	c.Assert(err, gc.IsNil)
 	c.Assert(parsed.Kind(), gc.Equals, names.SubnetTagKind)
-	c.Assert(parsed.Id(), gc.Equals, cidr)
-	c.Assert(parsed.String(), gc.Equals, names.SubnetTagKind+"-"+cidr)
+	c.Assert(parsed.Id(), gc.Equals, id)
+	c.Assert(parsed.String(), gc.Equals, names.SubnetTagKind+"-"+id)
 
 	f := func() {
 		tag = names.NewSubnetTag("foo")
 	}
-	c.Assert(f, gc.PanicMatches, "foo is not a valid subnet CIDR")
+	c.Assert(f, gc.PanicMatches, "foo is not a valid subnet ID")
 }
 
 var parseSubnetTagTests = []struct {
@@ -36,20 +36,8 @@ var parseSubnetTagTests = []struct {
 	tag: "",
 	err: names.InvalidTagError("", ""),
 }, {
-	tag:      "subnet-10.20.0.0/16",
-	expected: names.NewSubnetTag("10.20.0.0/16"),
-}, {
-	tag:      "subnet-2001:db8::/32",
-	expected: names.NewSubnetTag("2001:db8::/32"),
-}, {
-	tag: "subnet-fe80::3%zone1/10",
-	err: names.InvalidTagError("subnet-fe80::3%zone1/10", names.SubnetTagKind),
-}, {
-	tag: "subnet-10.20.30.40/16",
-	err: names.InvalidTagError("subnet-10.20.30.40/16", names.SubnetTagKind),
-}, {
-	tag: "subnet-2001:db8::123/32",
-	err: names.InvalidTagError("subnet-2001:db8::123/32", names.SubnetTagKind),
+	tag:      "subnet-16",
+	expected: names.NewSubnetTag("16"),
 }, {
 	tag: "subnet-foo",
 	err: names.InvalidTagError("subnet-foo", names.SubnetTagKind),

--- a/tag_test.go
+++ b/tag_test.go
@@ -40,8 +40,7 @@ var tagKindTests = []struct {
 	{tag: "ipaddress", err: `"ipaddress" is not a valid tag`},
 	{tag: "ipaddress-42424242-1111-2222-3333-0123456789ab", kind: names.IPAddressTagKind},
 	{tag: "subnet", err: `"subnet" is not a valid tag`},
-	{tag: "subnet-10.20.0.0/16", kind: names.SubnetTagKind},
-	{tag: "subnet-2001:db8::/32", kind: names.SubnetTagKind},
+	{tag: "subnet-16", kind: names.SubnetTagKind},
 	{tag: "space", err: `"space" is not a valid tag`},
 	{tag: "space-42", kind: names.SpaceTagKind},
 	{tag: "cloud", err: `"cloud" is not a valid tag`},
@@ -213,15 +212,10 @@ var parseTagTests = []struct {
 	tag:       "subnet-",
 	resultErr: `"subnet-" is not a valid subnet tag`,
 }, {
-	tag:        "subnet-10.20.0.0/16",
+	tag:        "subnet-16",
 	expectKind: names.SubnetTagKind,
 	expectType: names.SubnetTag{},
-	resultId:   "10.20.0.0/16",
-}, {
-	tag:        "subnet-2001:db8::/32",
-	expectKind: names.SubnetTagKind,
-	expectType: names.SubnetTag{},
-	resultId:   "2001:db8::/32",
+	resultId:   "16",
 }, {
 	tag:       "space-",
 	resultErr: `"space-" is not a valid space tag`,


### PR DESCRIPTION

A CIDR is not a unique identifier of a subnet for juju any longer.  Changing the SubnetTag to be an ID rather than a CIDR.  Use names.v2 for a SubnetTag as a CIDR if required.