### PR TITLE
Allow action ids to be <appname>-N

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -21,6 +21,7 @@ var parseActionTagTests = []struct {
 }{
 	{tag: "", err: names.InvalidTagError("", "")},
 	{tag: "action-f47ac10b-58cc-4372-a567-0e02b2c3d479", expected: names.NewActionTag("f47ac10b-58cc-4372-a567-0e02b2c3d479")},
+	{tag: "action-mariadb-1", expected: names.NewActionTag("mariadb-1")},
 	{tag: "action-012345678", err: names.InvalidTagError("action-012345678", "action")},
 	{tag: "action-1234567", err: names.InvalidTagError("action-1234567", "action")},
 	{tag: "bob", err: names.InvalidTagError("bob", "")},

--- a/equality_test.go
+++ b/equality_test.go
@@ -4,7 +4,6 @@
 package names
 
 import (
-	"github.com/juju/utils"
 	gc "gopkg.in/check.v1"
 )
 
@@ -21,7 +20,9 @@ var tagEqualityTests = []struct {
 	{NewUserTag("admin"), UserTag{name: "admin"}},
 	{NewUserTag("admin@local"), UserTag{name: "admin", domain: ""}},
 	{NewUserTag("admin@foobar"), UserTag{name: "admin", domain: "foobar"}},
-	{NewActionTag("01234567-aaaa-4bbb-8ccc-012345678901"), ActionTag{ID: stringToUUID("01234567-aaaa-4bbb-8ccc-012345678901")}},
+	{NewActionTag("01234567-aaaa-4bbb-8ccc-012345678901"), ActionTag{ID: "01234567-aaaa-4bbb-8ccc-012345678901"}},
+	{NewActionTag("mariadb-1"), ActionTag{ID: "mariadb-1"}},
+	{NewControllerAgentTag("1"), ControllerAgentTag{id: "1"}},
 }
 
 type equalitySuite struct{}
@@ -32,12 +33,4 @@ func (s *equalitySuite) TestTagEquality(c *gc.C) {
 	for _, tt := range tagEqualityTests {
 		c.Check(tt.want, gc.Equals, tt.expected)
 	}
-}
-
-func stringToUUID(id string) utils.UUID {
-	uuid, err := utils.UUIDFromString(id)
-	if err != nil {
-		panic(err)
-	}
-	return uuid
 }

--- a/tag_test.go
+++ b/tag_test.go
@@ -34,6 +34,7 @@ var tagKindTests = []struct {
 	{tag: "network", err: `"network" is not a valid tag`},
 	{tag: "ab01cd23-0123-4edc-9a8b-fedcba987654", err: `"ab01cd23-0123-4edc-9a8b-fedcba987654" is not a valid tag`},
 	{tag: "action-ab01cd23-0123-4edc-9a8b-fedcba987654", kind: names.ActionTagKind},
+	{tag: "action-mariadb-1", kind: names.ActionTagKind},
 	{tag: "volume-0", kind: names.VolumeTagKind},
 	{tag: "storage-data-0", kind: names.StorageTagKind},
 	{tag: "filesystem-0", kind: names.FilesystemTagKind},
@@ -182,6 +183,11 @@ var parseTagTests = []struct {
 	expectKind: names.ActionTagKind,
 	expectType: names.ActionTag{},
 	resultId:   "abedaf33-3212-4fde-aeca-87356432deca",
+}, {
+	tag:        "action-mariadb-1",
+	expectKind: names.ActionTagKind,
+	expectType: names.ActionTag{},
+	resultId:   "mariadb-1",
 }, {
 	tag:        "volume-2",
 	expectKind: names.VolumeTagKind,


### PR DESCRIPTION
For actions v2, we will transition to user friendly IDs; not a UUID but `<appname>-N`.
This PR adds support for making action tags with the new id format.