### PR TITLE
Action tags v2 are now numbers

### DIFF
--- a/action.go
+++ b/action.go
@@ -14,10 +14,8 @@ import (
 const ActionTagKind = "action"
 
 // ActionSnippet defines the regexp for a valid Action Id.
-// Actions are associated with applications, so we identify actions
-// in a human friendly way by naming them after their application,
-// with a unique, incrementing number.
-const ActionSnippet = "(" + ApplicationSnippet + ")-" + NumberSnippet
+// Actions are identified by a unique, incrementing number.
+const ActionSnippet = NumberSnippet
 
 var validActionV2 = regexp.MustCompile("^" + ActionSnippet + "$")
 
@@ -33,7 +31,7 @@ func NewActionTag(id string) ActionTag {
 		return ActionTag{ID: uuid.String()}
 	}
 
-	// Actions v2 use <appname>-N.
+	// Actions v2 use a number.
 	if !validActionV2.MatchString(id) {
 		panic(fmt.Sprintf("invalid action id %q", id))
 	}
@@ -60,7 +58,7 @@ func (t ActionTag) Id() string     { return t.ID }
 // IsValidAction returns whether id is a valid action id.
 func IsValidAction(id string) bool {
 	// UUID is for actions v1
-	// <appname>-N is for actions V2.
+	// N is for actions V2.
 	return utils.IsValidUUIDString(id) ||
 		validActionV2.MatchString(id)
 }

--- a/action_test.go
+++ b/action_test.go
@@ -21,9 +21,8 @@ var parseActionTagTests = []struct {
 }{
 	{tag: "", err: names.InvalidTagError("", "")},
 	{tag: "action-f47ac10b-58cc-4372-a567-0e02b2c3d479", expected: names.NewActionTag("f47ac10b-58cc-4372-a567-0e02b2c3d479")},
-	{tag: "action-mariadb-1", expected: names.NewActionTag("mariadb-1")},
-	{tag: "action-012345678", err: names.InvalidTagError("action-012345678", "action")},
-	{tag: "action-1234567", err: names.InvalidTagError("action-1234567", "action")},
+	{tag: "action-1", expected: names.NewActionTag("1")},
+	{tag: "action-foo", err: names.InvalidTagError("action-foo", "action")},
 	{tag: "bob", err: names.InvalidTagError("bob", "")},
 	{tag: "application-ned", err: names.InvalidTagError("application-ned", names.ActionTagKind)}}
 

--- a/equality_test.go
+++ b/equality_test.go
@@ -21,7 +21,7 @@ var tagEqualityTests = []struct {
 	{NewUserTag("admin@local"), UserTag{name: "admin", domain: ""}},
 	{NewUserTag("admin@foobar"), UserTag{name: "admin", domain: "foobar"}},
 	{NewActionTag("01234567-aaaa-4bbb-8ccc-012345678901"), ActionTag{ID: "01234567-aaaa-4bbb-8ccc-012345678901"}},
-	{NewActionTag("mariadb-1"), ActionTag{ID: "mariadb-1"}},
+	{NewActionTag("1"), ActionTag{ID: "1"}},
 	{NewControllerAgentTag("1"), ControllerAgentTag{id: "1"}},
 }
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -34,7 +34,7 @@ var tagKindTests = []struct {
 	{tag: "network", err: `"network" is not a valid tag`},
 	{tag: "ab01cd23-0123-4edc-9a8b-fedcba987654", err: `"ab01cd23-0123-4edc-9a8b-fedcba987654" is not a valid tag`},
 	{tag: "action-ab01cd23-0123-4edc-9a8b-fedcba987654", kind: names.ActionTagKind},
-	{tag: "action-mariadb-1", kind: names.ActionTagKind},
+	{tag: "action-1", kind: names.ActionTagKind},
 	{tag: "volume-0", kind: names.VolumeTagKind},
 	{tag: "storage-data-0", kind: names.StorageTagKind},
 	{tag: "filesystem-0", kind: names.FilesystemTagKind},
@@ -184,10 +184,10 @@ var parseTagTests = []struct {
 	expectType: names.ActionTag{},
 	resultId:   "abedaf33-3212-4fde-aeca-87356432deca",
 }, {
-	tag:        "action-mariadb-1",
+	tag:        "action-1",
 	expectKind: names.ActionTagKind,
 	expectType: names.ActionTag{},
-	resultId:   "mariadb-1",
+	resultId:   "1",
 }, {
 	tag:        "volume-2",
 	expectKind: names.VolumeTagKind,


### PR DESCRIPTION
For actions v2, we've decided to use numbers as the tag id, rather than `<actionname-N>`.