### PR TITLE
Allow _default to be a valid space.

### DIFF
--- a/space.go
+++ b/space.go
@@ -17,6 +17,11 @@ var validSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
 
 // IsValidSpace reports whether name is a valid space name.
 func IsValidSpace(name string) bool {
+	if name == "_default" {
+		// _default is a special case for the default name of
+		// juju's default space.
+		return true
+	}
 	return validSpace.MatchString(name)
 }
 

--- a/space_test.go
+++ b/space_test.go
@@ -34,6 +34,8 @@ var spaceNameTests = []struct {
 	{pattern: "also_not", valid: false},
 	{pattern: "a--", valid: false},
 	{pattern: "foo-2", valid: true},
+	{pattern: "_default", valid: true},
+	{pattern: "_foo", valid: false},
 }
 
 func (s *spaceSuite) TestSpaceNames(c *gc.C) {


### PR DESCRIPTION
Allow _default to be a valid space.
This is a special case for the name of juju's default space's default name.