### PR TITLE
Granular validation errors

### DIFF
--- a/application.go
+++ b/application.go
@@ -5,29 +5,84 @@ package names
 
 import (
 	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/juju/errors"
 )
 
+// ApplicationTagKind defines a tag for identifying applications.
 const ApplicationTagKind = "application"
 
 const (
+	// ApplicationSnippet is a non-compiled regexp that can be composed with
+	// other snippets to form a valid application regexp.
 	ApplicationSnippet = "(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)"
-	NumberSnippet      = "(?:0|[1-9][0-9]*)"
 )
 
-var validApplication = regexp.MustCompile("^" + ApplicationSnippet + "$")
+var (
+	validApplication = regexp.MustCompile("^" + ApplicationSnippet + "$")
+	tailNumberSuffix = regexp.MustCompile("-[0-9]+$")
+)
 
 // IsValidApplication returns whether name is a valid application name.
 func IsValidApplication(name string) bool {
 	return validApplication.MatchString(name)
 }
 
+// ValidateApplicationName takes a name and attempts to validate the application
+// name, before returning a reason why it's not valid.
+//
+// This should supersede IsValidApplication. It provides a lot more granular
+// information about why something might be wrong, which is a much better UX.
+func ValidateApplicationName(name string) error {
+	if IsValidApplication(name) {
+		return nil
+	}
+
+	// If the application has uppercase characters, bail out and explain
+	// why.
+	if uppercaseChar.MatchString(name) {
+		return errors.Errorf("invalid application name %q, unexpected uppercase character", name)
+	}
+	// If the application ends up being suffixed by a number, then we want
+	// to mention it to users why.
+	if tailNumberSuffix.MatchString(name) {
+		return errors.Errorf("invalid application name %q, unexpected number(s) found after last hyphen", name)
+	}
+
+	index := strings.IndexFunc(name, invalidRuneForApplicationName)
+	if index < 0 {
+		return errors.Errorf("invalid application name %q", name)
+	}
+
+	// We have to ensure that we don't break up multi-rune characters, by
+	// just selecting the index. Instead look at a slice of runes and use
+	// the first one.
+	invalidRune := []rune(name[index:])[0]
+	return errors.Errorf("invalid application name %q, unexpected character %c", name, invalidRune)
+}
+
+// invalidRuneForApplicationName works out if there is a valid application rune.
+func invalidRuneForApplicationName(r rune) bool {
+	if (r >= 'a' && r <= 'z') || unicode.IsNumber(r) || r == '-' {
+		return false
+	}
+	return true
+}
+
+// ApplicationTag defines a named tagged application.
 type ApplicationTag struct {
 	Name string
 }
 
 func (t ApplicationTag) String() string { return t.Kind() + "-" + t.Id() }
-func (t ApplicationTag) Kind() string   { return ApplicationTagKind }
-func (t ApplicationTag) Id() string     { return t.Name }
+
+// Kind returns the application tag.
+func (t ApplicationTag) Kind() string { return ApplicationTagKind }
+
+// Id returns the underlying name of an application as the Id.
+func (t ApplicationTag) Id() string { return t.Name }
 
 // NewApplicationTag returns the tag for the application with the given name.
 func NewApplicationTag(applicationName string) ApplicationTag {

--- a/application_test.go
+++ b/application_test.go
@@ -87,3 +87,28 @@ func (s *applicationSuite) TestParseApplicationTag(c *gc.C) {
 		c.Check(got, gc.Equals, t.expected)
 	}
 }
+
+func (s *applicationSuite) TestValidateApplicationName(c *gc.C) {
+	tests := []struct {
+		Name  string
+		Error string
+	}{
+		{
+			Name:  "application-1",
+			Error: `invalid application name "application-1", unexpected number\(s\) found after last hyphen`,
+		},
+		{
+			Name:  "Application",
+			Error: `invalid application name "Application", unexpected uppercase character`,
+		},
+		{
+			Name:  "app£name",
+			Error: `invalid application name "app£name", unexpected character £`,
+		},
+	}
+	for i, test := range tests {
+		c.Logf("test %d", i)
+		err := names.ValidateApplicationName(test.Name)
+		c.Assert(err, gc.ErrorMatches, test.Error)
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -5,10 +5,24 @@ package names
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/utils/v2"
+)
+
+const (
+	// UppercaseSnippet declares an non-compiled regex string for matching
+	// uppercase characters.
+	UppercaseSnippet = "[A-Z]"
+	// NumberSnippet is a non-compiled regexp that can be composed with other
+	// snippets for validating small number sequences.
+	NumberSnippet = "(?:0|[1-9][0-9]*)"
+)
+
+var (
+	uppercaseChar = regexp.MustCompile(UppercaseSnippet)
 )
 
 // A Tag tags things that are taggable. Its purpose is to uniquely


### PR DESCRIPTION
The names package is a great way to check if a name is valid, but really
struggles to tell you why a given name is valid. The following change
starts to do that by exposing a ValidateApplicationName, which will tell
you why a given name is wrong.

The code is rather dull, but is effective in that we try and be helpful
upfront (uppercase issues or numbers after the last hyphen), then just
point out an issue in a more programtic sense. Whilst the last is great
if you're a programmer, it's more cryptic for general users.