### PR TITLE
Fix cloudcredential format

### DIFF
--- a/cloudcredential.go
+++ b/cloudcredential.go
@@ -13,7 +13,7 @@ import (
 const CloudCredentialTagKind = "cloudcred"
 
 var (
-	cloudCredentialNameSnippet = "[a-zA-Z][a-zA-Z0-9.@_+-]*"
+	cloudCredentialNameSnippet = "[a-zA-Z0-9][a-zA-Z0-9.@_+-]*"
 	validCloudCredentialName   = regexp.MustCompile("^" + cloudCredentialNameSnippet + "$")
 	validCloudCredential       = regexp.MustCompile(
 		"^" +


### PR DESCRIPTION
Related bug: https://bugs.launchpad.net/juju/+bug/1896636

Cloud credential names starting with a number were invalid. With this is fixed.