### PR TITLE
Introduces typed errors for tag parsing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/juju/names/v4
 go 1.17
 
 require (
-	github.com/juju/errors v0.0.0-20220203013757-bd733f3c86b9
+	github.com/juju/errors v1.0.0
 	github.com/juju/testing v0.0.0-20220203020004-a0ff61f03494
 	github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0b
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=
 github.com/juju/errors v0.0.0-20220203013757-bd733f3c86b9 h1:EJHbsNpQyupmMeWTq7inn+5L/WZ7JfzCVPJ+DP9McCQ=
 github.com/juju/errors v0.0.0-20220203013757-bd733f3c86b9/go.mod h1:TRm7EVGA3mQOqSVcBySRY7a9Y1/gyVhh/WTCnc5sD4U=
+github.com/juju/errors v1.0.0 h1:yiq7kjCLll1BiaRuNY53MGI0+EQ3rF6GB+wvboZDefM=
+github.com/juju/errors v1.0.0/go.mod h1:B5x9thDqx0wIMH3+aLIMP9HjItInYWObRovoCFM5Qe8=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=

--- a/tag.go
+++ b/tag.go
@@ -13,6 +13,8 @@ import (
 )
 
 const (
+	ErrorNotValid = errors.ConstError("not a valid tag")
+
 	// UppercaseSnippet declares an non-compiled regex string for matching
 	// uppercase characters.
 	UppercaseSnippet = "[A-Z]"
@@ -233,9 +235,9 @@ func ParseTag(tag string) (Tag, error) {
 
 func invalidTagError(tag, kind string) error {
 	if kind != "" {
-		return fmt.Errorf("%q is not a valid %s tag", tag, kind)
+		return fmt.Errorf("%q is %w of kind %s", tag, ErrorNotValid, kind)
 	}
-	return fmt.Errorf("%q is not a valid tag", tag)
+	return fmt.Errorf("%q is %w", tag, ErrorNotValid)
 }
 
 // ReadableString returns a human-readable string from the tag passed in.

--- a/tag_test.go
+++ b/tag_test.go
@@ -87,7 +87,7 @@ var parseTagTests = []struct {
 	tag:        "machine-#",
 	expectKind: names.MachineTagKind,
 	expectType: names.MachineTag{},
-	resultErr:  `"machine-#" is not a valid machine tag`,
+	resultErr:  `"machine-#" is not a valid tag of kind machine`,
 }, {
 	tag:        "unit-wordpress-0",
 	expectKind: names.UnitTagKind,
@@ -102,7 +102,7 @@ var parseTagTests = []struct {
 	tag:        "unit-#",
 	expectKind: names.UnitTagKind,
 	expectType: names.UnitTag{},
-	resultErr:  `"unit-#" is not a valid unit tag`,
+	resultErr:  `"unit-#" is not a valid tag of kind unit`,
 }, {
 	tag:        "application-wordpress",
 	expectKind: names.ApplicationTagKind,
@@ -112,7 +112,7 @@ var parseTagTests = []struct {
 	tag:        "application-#",
 	expectKind: names.ApplicationTagKind,
 	expectType: names.ApplicationTag{},
-	resultErr:  `"application-#" is not a valid application tag`,
+	resultErr:  `"application-#" is not a valid tag of kind application`,
 }, {
 	tag:        "applicationoffer-hosted-mysql",
 	expectKind: names.ApplicationOfferTagKind,
@@ -122,7 +122,7 @@ var parseTagTests = []struct {
 	tag:        "applicationoffer-#",
 	expectKind: names.ApplicationOfferTagKind,
 	expectType: names.ApplicationOfferTag{},
-	resultErr:  `"applicationoffer-#" is not a valid applicationoffer tag`,
+	resultErr:  `"applicationoffer-#" is not a valid tag of kind applicationoffer`,
 }, {
 	tag:        "environment-f47ac10b-58cc-4372-a567-0e02b2c3d479",
 	expectKind: names.EnvironTagKind,
@@ -147,12 +147,12 @@ var parseTagTests = []struct {
 	tag:        "environment-/",
 	expectKind: names.EnvironTagKind,
 	expectType: names.EnvironTag{},
-	resultErr:  `"environment-/" is not a valid environment tag`,
+	resultErr:  `"environment-/" is not a valid tag of kind environment`,
 }, {
 	tag:        "model-/",
 	expectKind: names.ModelTagKind,
 	expectType: names.ModelTag{},
-	resultErr:  `"model-/" is not a valid model tag`,
+	resultErr:  `"model-/" is not a valid tag of kind model`,
 }, {
 	tag:        "user-foo",
 	expectKind: names.UserTagKind,
@@ -167,17 +167,17 @@ var parseTagTests = []struct {
 	tag:        "user-/",
 	expectKind: names.UserTagKind,
 	expectType: names.UserTag{},
-	resultErr:  `"user-/" is not a valid user tag`,
+	resultErr:  `"user-/" is not a valid tag of kind user`,
 }, {
 	tag:        "action-00000000-abcd",
 	expectKind: names.ActionTagKind,
 	expectType: names.ActionTag{},
-	resultErr:  `"action-00000000-abcd" is not a valid action tag`,
+	resultErr:  `"action-00000000-abcd" is not a valid tag of kind action`,
 }, {
 	tag:        "action-00000033",
 	expectKind: names.ActionTagKind,
 	expectType: names.ActionTag{},
-	resultErr:  `"action-00000033" is not a valid action tag`,
+	resultErr:  `"action-00000033" is not a valid tag of kind action`,
 }, {
 	tag:        "action-abedaf33-3212-4fde-aeca-87356432deca",
 	expectKind: names.ActionTagKind,
@@ -213,7 +213,7 @@ var parseTagTests = []struct {
 	resultErr: `"foo" is not a valid tag`,
 }, {
 	tag:       "ipaddress-",
-	resultErr: `"ipaddress-" is not a valid ipaddress tag`,
+	resultErr: `"ipaddress-" is not a valid tag of kind ipaddress`,
 }, {
 	tag:        "ipaddress-42424242-1111-2222-3333-0123456789ab",
 	expectKind: names.IPAddressTagKind,
@@ -221,7 +221,7 @@ var parseTagTests = []struct {
 	resultId:   "42424242-1111-2222-3333-0123456789ab",
 }, {
 	tag:       "subnet-",
-	resultErr: `"subnet-" is not a valid subnet tag`,
+	resultErr: `"subnet-" is not a valid tag of kind subnet`,
 }, {
 	tag:        "subnet-16",
 	expectKind: names.SubnetTagKind,
@@ -229,7 +229,7 @@ var parseTagTests = []struct {
 	resultId:   "16",
 }, {
 	tag:       "space-",
-	resultErr: `"space-" is not a valid space tag`,
+	resultErr: `"space-" is not a valid tag of kind space`,
 }, {
 	tag:        "space-myspace1",
 	expectKind: names.SpaceTagKind,
@@ -254,7 +254,7 @@ var parseTagTests = []struct {
 	tag:        "caasmodel-/",
 	expectKind: names.CAASModelTagKind,
 	expectType: names.CAASModelTag{},
-	resultErr:  `"caasmodel-/" is not a valid caasmodel tag`,
+	resultErr:  `"caasmodel-/" is not a valid tag of kind caasmodel`,
 }, {
 	tag:        "controller-f47ac10b-58cc-4372-a567-0e02b2c3d479",
 	expectKind: names.ControllerTagKind,
@@ -269,7 +269,7 @@ var parseTagTests = []struct {
 	tag:        "controller-invalid",
 	expectKind: names.ControllerTagKind,
 	expectType: names.ControllerTag{},
-	resultErr:  `"controller-invalid" is not a valid controller tag`,
+	resultErr:  `"controller-invalid" is not a valid tag of kind controller`,
 }}
 
 var makeTag = map[string]func(string) names.Tag{


### PR DESCRIPTION
- Upgrades juju/errors usage to v1 for ConstError support.
- Introduces a new typed error as part of Tag parsing.
- Changes the kind string error message to support the parsed tag error message.