### PR TITLE
feat: add check for max number of characters for model name

### DIFF
--- a/model.go
+++ b/model.go
@@ -22,6 +22,9 @@ var validUUID = regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]
 // Lowercase letters, digits and (non-leading) hyphens, as per LP:1568944 #5.
 var validModelName = regexp.MustCompile(`^[a-z0-9]+[a-z0-9-]*$`)
 
+// Maximum number of characters for the model name.
+const MaxCharactersModelName = 128
+
 // NewModelTag returns the tag of an model with the given model UUID.
 func NewModelTag(uuid string) ModelTag {
 	return ModelTag{uuid: uuid}
@@ -52,5 +55,5 @@ func IsValidModel(id string) bool {
 
 // IsValidModelName returns whether name is a valid string safe for a model name.
 func IsValidModelName(name string) bool {
-	return validModelName.MatchString(name)
+	return len(name) <= MaxCharactersModelName && validModelName.MatchString(name)
 }

--- a/model_test.go
+++ b/model_test.go
@@ -4,6 +4,8 @@
 package names_test
 
 import (
+	"strings"
+
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
 )
@@ -63,6 +65,14 @@ var modelNameTest = []struct {
 	name:     "foo-bar",
 	expected: true,
 }, {
+	test:     "Non-hyphenated true",
+	name:     "foobar",
+	expected: true,
+}, {
+	test:     "Start hyphenated false",
+	name:     "-foobar",
+	expected: false,
+}, {
 	test:     "Whitespsce false",
 	name:     "foo bar",
 	expected: false,
@@ -73,6 +83,14 @@ var modelNameTest = []struct {
 }, {
 	test:     "At sign false",
 	name:     "foo@bar",
+	expected: false,
+}, {
+	test:     "Longest model name true",
+	name:     strings.Repeat("a", names.MaxCharactersModelName),
+	expected: true,
+}, {
+	test:     "Longest+1 model name false",
+	name:     strings.Repeat("a", names.MaxCharactersModelName+1),
 	expected: false,
 }}
 


### PR DESCRIPTION
This PR adds a check for a maximum number of characters for model name.

This is to address this bug: https://bugs.launchpad.net/juju/+bug/2080003

100 as max length is just a magic number, if you have better suggestion I am open.
To address the bug: the max size for filename for debian, mac, and windows seems to be 255 generally. 

> I could have made the same check by changing the regular expression, but I think it's better to check it directly with `len` because it's clearer and more performant. But I am open to hearing your opinion.