### PR TITLE
chore: add name, source, revision and arch to charm tag

### DIFF
--- a/charm.go
+++ b/charm.go
@@ -6,62 +6,48 @@ package names
 import (
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 )
 
 // CharmTagKind specifies charm tag kind
 const CharmTagKind = "charm"
 
-// Valid charm url can be either in V1 or V3 format. (V2 is a
-// charmstore web URL like https://jujucharms.com/postgresql/105, but
-// that's not valid as a tag.)
-//
-// V1 is of the form:
-// schema:~user/series/name-revision
-// where
-//     schema    is optional and can be either "local" or "cs".
-//               When not supplied, "cs" is implied.
-//     user      is optional and is only applicable for "cs" schema
-//     series    is optional and is a valid series name
-//     name      is mandatory and is the name of the charm
-//     revision  is optional and can be -1 if revision is unset
-//
-// V3 is of the form
-// schema:user/name/series/revision
-// with the same fields and constraints as the V1 format.
-
-var (
-	// SeriesSnippet is a regular expression representing series
-	SeriesSnippet = "[a-z]+([a-z0-9]+)?"
-
-	// CharmNameSnippet is a regular expression representing charm name
-	CharmNameSnippet = "[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*"
-
-	localSchemaSnippet        = "local:"
-	v1CharmStoreSchemaSnippet = "cs:(~" + validUserNameSnippet + "/)?"
-	revisionSnippet           = "(-1|0|[1-9][0-9]*)"
-
-	validV1CharmRegEx = regexp.MustCompile("^(" +
-		localSchemaSnippet + "|" +
-		v1CharmStoreSchemaSnippet + ")?(" +
-		SeriesSnippet + "/)?" +
-		CharmNameSnippet + "(-" +
-		revisionSnippet + ")?$")
-
-	v3CharmStoreSchemaSnippet = "(cs:)?(" + validUserNameSnippet + "/)?"
-
-	validV3CharmRegEx = regexp.MustCompile("^(" +
-		localSchemaSnippet + "|" +
-		v3CharmStoreSchemaSnippet + ")" +
-		CharmNameSnippet + "(/" +
-		SeriesSnippet + ")?(/" +
-		revisionSnippet + ")?$")
-)
-
 // CharmTag represents tag for charm
 // using charm's URL
 type CharmTag struct {
-	url string
+	schema       string
+	architecture string
+	series       string
+	name         string
+	revision     int
 }
+
+var (
+	// schemaSnippet is a regex snippet representing a valid charm URL
+	// schemas
+	schemaSnippet = "(local:|ch:)?"
+	// archSnippet is a regex snippet representing valid architectures
+	archSnippet = "([a-z]+([a-z0-9]+)?/)?"
+	// supportedArches is a regular expression representing supported
+	// architectures
+	supportedArches = regexp.MustCompile("^(amd64|arm64|ppc64el|s390x|riscv64)$")
+	// seriesSnippet is a regex snippet representing valid series
+	seriesSnippet = "([a-z]+([a-z0-9]+)?/)?"
+	// charmNameSnippet is a regex snippet representing valid charm
+	// names
+	charmNameSnippet = "[a-z][a-z0-9]*(-[a-z0-9]*[a-z][a-z0-9]*)*"
+	// revisionSnippet is a regex snippet representing valid revisions
+	revisionSnippet = "(-(-1|0|[1-9][0-9]*))?"
+	// charmURLRegex is a regular expression for a valid charm url
+	// (schema:(arch/)?(series/)?name(-revision)?)
+	charmURLRegex = regexp.MustCompile("^" +
+		schemaSnippet +
+		archSnippet +
+		seriesSnippet +
+		charmNameSnippet +
+		revisionSnippet + "$")
+)
 
 // String satisfies Tag interface.
 // Produces string representation of charm tag.
@@ -72,16 +58,57 @@ func (t CharmTag) String() string { return t.Kind() + "-" + t.Id() }
 func (t CharmTag) Kind() string { return CharmTagKind }
 
 // Id satisfies Tag interface.
-// Returns charm URL.
-func (t CharmTag) Id() string { return t.url }
-
-// NewCharmTag returns the tag for the charm with the given url.
-// It will panic if the given charm url is not valid.
-func NewCharmTag(charmURL string) CharmTag {
-	if !IsValidCharm(charmURL) {
-		panic(fmt.Sprintf("%q is not a valid charm name", charmURL))
+// NOTE(nvinuesa): Currently, this method returns the URL of the charm as
+// it's accepted today. This might change in the future.
+func (t CharmTag) Id() string {
+	var parts []string
+	if t.architecture != "" {
+		parts = append(parts, t.architecture)
 	}
-	return CharmTag{url: charmURL}
+	if t.series != "" {
+		parts = append(parts, t.series)
+	}
+	if t.revision >= 0 {
+		parts = append(parts, fmt.Sprintf("%s-%d", t.name, t.revision))
+	} else {
+		parts = append(parts, t.name)
+	}
+	return fmt.Sprintf("%s:%s", t.schema, strings.Join(parts, "/"))
+}
+
+// Source returns the source of the charm.
+func (t CharmTag) Source() string {
+	if t.schema == "local" {
+		return "local"
+	}
+	// By default, assume charmhub.
+	return "charmhub"
+}
+
+// Architecture returns the architecture of the charm.
+func (t CharmTag) Architecture() string {
+	return t.architecture
+}
+
+// Series returns the series of the charm.
+func (t CharmTag) Series() string {
+	return t.series
+}
+
+// Name returns the name of the charm.
+func (t CharmTag) Name() string {
+	return t.name
+}
+
+// Revision returns the revision of the charm.
+func (t CharmTag) Revision() int {
+	return t.revision
+}
+
+// NewCharmTag returns the tag for the charm with the given name, source,
+// revision and architecture.
+func NewCharmTag(id string) CharmTag {
+	return parseCharmURL(id)
 }
 
 var emptyTag = CharmTag{}
@@ -101,5 +128,69 @@ func ParseCharmTag(charmTag string) (CharmTag, error) {
 
 // IsValidCharm returns whether name is a valid charm url.
 func IsValidCharm(url string) bool {
-	return validV1CharmRegEx.MatchString(url) || validV3CharmRegEx.MatchString(url)
+	return charmURLRegex.MatchString(url)
+}
+
+func parseCharmURL(url string) CharmTag {
+	// URLs without schema are assumed to be charmhub charms.
+	schema := "ch:"
+	nameRev := ""
+	arch := ""
+	series := ""
+	urlParts := strings.Split(url, ":")
+	if len(urlParts) == 2 {
+		schema = urlParts[0]
+		url = urlParts[1]
+	}
+	pathParts := strings.Split(url, "/")
+	switch len(pathParts) {
+	case 3:
+		arch, series, nameRev = pathParts[0], pathParts[1], pathParts[2]
+	case 2:
+		// Since both the architecture and series are optional,
+		// the first part can be either architecture or series.
+		// To differentiate between them, we go ahead and try to
+		// validate the first part as an architecture to decide.
+
+		if isValidArchitecture(pathParts[0]) {
+			arch, nameRev = pathParts[0], pathParts[1]
+		} else {
+			series, nameRev = pathParts[0], pathParts[1]
+		}
+
+	default:
+		nameRev = pathParts[0]
+	}
+	name, revision := extractRevision(nameRev)
+	return CharmTag{
+		schema:       schema,
+		architecture: arch,
+		series:       series,
+		name:         name,
+		revision:     revision,
+	}
+}
+
+func extractRevision(name string) (string, int) {
+	revision := -1
+	for i := len(name) - 1; i > 0; i-- {
+		c := name[i]
+		if c >= '0' && c <= '9' {
+			continue
+		}
+		if c == '-' && i != len(name)-1 {
+			var err error
+			revision, err = strconv.Atoi(name[i+1:])
+			if err != nil {
+				panic(err) // We just checked it was right.
+			}
+			name = name[:i]
+		}
+		break
+	}
+	return name, revision
+}
+
+func isValidArchitecture(architecture string) bool {
+	return supportedArches.MatchString(architecture)
 }

--- a/charm_test.go
+++ b/charm_test.go
@@ -17,47 +17,23 @@ type charmSuite struct{}
 var _ = gc.Suite(&charmSuite{})
 
 var validCharmURLs = []string{"charm",
-	// V1 charm urls.
-	"local:charm",
-	"local:charm--1",
-	"local:charm-1",
-	"local:series/charm",
-	"local:series/charm-3",
-	"local:series/charm-0",
-	"cs:~user/charm",
-	"cs:~user/charm-1",
-	"cs:~user/series/charm",
-	"cs:~user/series/charm-1",
-	"cs:series/charm",
-	"cs:series/charm-with-long-name",
-	"cs:series/charm-3",
-	"cs:series/charm-0",
-	"cs:charm",
-	"cs:charm--1",
-	"cs:charm-1",
 	"charm",
 	"charm-1",
-	"series/charm",
+	"amd64/charm",
+	"amd64/charm-42",
+	"seriesorarch/charm",
 	"series/charm-1",
-
-	// V3 charm urls.
-	"local:charm-with-long2-name/series/2",
-	"local:charm-with-long2-name/series",
-	"local:charm-with-long2-name/2",
-	"cs:user/charm-with-long-name/series/2",
-	"cs:charm-with-long2-name/series/2",
-	"cs:user/charm-with-long-name/2",
-	"cs:user/charm-with-long-name/series",
-	"cs:charm-with-long-name/2",
-	"cs:charm-with-long-name/series",
-	"cs:user/charm-with-long-name",
-	"user/charm-with-long-name/series/2",
-	"charm-with-long2-name/series/2",
-	"user/charm-with-long-name/2",
-	"user/charm-with-long-name/series",
-	"charm-with-long-name/2",
-	"charm-with-long-name/series",
-	"user/charm-with-long-name",
+	"arch/series/charm",
+	"arch/series/charm-1",
+	"local:arch/series/charm-with-long2-name",
+	"local:series/charm-with-long2-name-2",
+	"local:arch/charm-with-long2-name-2",
+	"ch:series/charm-with-long2-name-2",
+	"ch:charm-with-long-name",
+	"ch:charm-with-long-name-2",
+	"ch:seriesorarch/charm-with-long-name",
+	"ch:arch/series/charm-with-long-name",
+	"ch:arch/series/charm-with-long-name-2",
 }
 
 func (s *charmSuite) TestValidCharmURLs(c *gc.C) {
@@ -69,13 +45,17 @@ func (s *charmSuite) TestValidCharmURLs(c *gc.C) {
 
 func (s *charmSuite) TestInvalidCharmURLs(c *gc.C) {
 	invalidURLs := []string{"",
-		"local:~user/charm",          // false: user on local
-		"local:~user/series/charm",   // false: user on local
-		"local:~user/series/charm-1", // false: user on local
-		"local:charm--2",             // false: only -1 is a valid negative revision
-		"blah:charm-2",               // false: invalid schema
-		"local:series/charm-01",      // false: revision is funny
-		"local:user/name/series/2",   // false: local charms can't have users
+		"local:~user/charm",              // false: user on local
+		"local:~user/series/charm",       // false: user on local
+		"local:~user/series/charm-1",     // false: user on local
+		"ch:~user/series/charm-1",        // false: user on charmhub
+		"local:charm--2",                 // false: only -1 is a valid negative revision
+		"blah:charm-2",                   // false: invalid schema
+		"local:series/charm-01",          // false: revision is funny
+		"local:user/name/series/2",       // false: local charms can't have users
+		"wrongschema:arch/series/name-1", // false: wrong schema
+		"part0/part1/part2/part3/part4",  // false: too many parts
+		"ch:part0/part1/part2/part3",     // false: too many parts, with schema
 	}
 	for _, url := range invalidURLs {
 		c.Logf("Processing tag %q", url)
@@ -99,6 +79,35 @@ func (s *charmSuite) TestParseCharmTagInvalid(c *gc.C) {
 	for _, aTag := range invalidTags {
 		c.Logf("Processing tag %q", aTag)
 		s.assertParseCharmTagInvalid(c, aTag)
+	}
+}
+
+func (s *charmSuite) TestCharmFields(c *gc.C) {
+	for _, test := range []struct {
+		tag    string
+		source string
+		arch   string
+		series string
+		name   string
+		rev    int
+	}{
+		{"amd64/mysql-42", "charmhub", "amd64", "", "mysql", 42},
+		{"ch:amd64/mysql-42", "charmhub", "amd64", "", "mysql", 42},
+		{"ch:amd64/focal/mysql-42", "charmhub", "amd64", "focal", "mysql", 42},
+		{"ch:focal/mysql-42", "charmhub", "", "focal", "mysql", 42},
+		{"ch:mysql-42", "charmhub", "", "", "mysql", 42},
+		{"ch:mysql", "charmhub", "", "", "mysql", -1},
+		{"local:trusty/mysql-42", "local", "", "trusty", "mysql", 42},
+		{"local:mysql-42", "local", "", "", "mysql", 42},
+	} {
+		c.Logf("Processing tag %q", test.tag)
+		tag, err := names.ParseCharmTag(names.CharmTagKind + "-" + test.tag)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(tag.Source(), gc.Equals, test.source)
+		c.Check(tag.Architecture(), gc.Equals, test.arch)
+		c.Check(tag.Series(), gc.Equals, test.series)
+		c.Check(tag.Name(), gc.Equals, test.name)
+		c.Check(tag.Revision(), gc.Equals, test.rev)
 	}
 }
 


### PR DESCRIPTION
This patch refactors and updates the charm tag.

First, it updates the validation regular expressions to match our current acceptance of the charm URLs and removes legacy accepted ones (like cs: and ~user).
Second, it adds methods (and inner fields) to return the charm's Name, Source, Architecture (optional) and Revision.

Tests were added for the new fields/methods and updated regarding the accepted URLs.