### PR TITLE
feat: support UUID v7 tags for spaces and subnets

### DIFF
--- a/space.go
+++ b/space.go
@@ -13,11 +13,16 @@ const (
 	SpaceSnippet = "(?:[a-z0-9]+(?:-[a-z0-9]+)*)"
 )
 
-var validSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
+var (
+	validSpace = regexp.MustCompile("^" + UUIDv7Snippet + "$")
+	// Deprecated: Juju 4.0 should have space IDs in the form of UUIDv7.
+	fallbackValidSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
+)
 
 // IsValidSpace reports whether name is a valid space name.
 func IsValidSpace(name string) bool {
-	return validSpace.MatchString(name)
+	return validSpace.MatchString(name) ||
+		fallbackValidSpace.MatchString(name)
 }
 
 type SpaceTag struct {

--- a/space_test.go
+++ b/space_test.go
@@ -61,6 +61,9 @@ var parseSpaceTagTests = []struct {
 	tag:      "space-1",
 	expected: names.NewSpaceTag("1"),
 }, {
+	tag:      "space-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
+	expected: names.NewSpaceTag("0195847b-95bb-7ca1-a7ee-2211d802d5b3"),
+}, {
 	tag: "-space1",
 	err: names.InvalidTagError("-space1", ""),
 }}

--- a/subnet.go
+++ b/subnet.go
@@ -10,11 +10,16 @@ import (
 
 const SubnetTagKind = "subnet"
 
-var validSubnet = regexp.MustCompile("^" + NumberSnippet + "$")
+var (
+	validSubnet = regexp.MustCompile("^" + UUIDv7Snippet + "$")
+	// Deprecated: Juju 4.0 should have subnet IDs in the form of UUIDv7.
+	fallbackValidSubnet = regexp.MustCompile("^" + NumberSnippet + "$")
+)
 
 // IsValidSubnet returns whether id is a valid subnet id.
 func IsValidSubnet(id string) bool {
-	return validSubnet.MatchString(id)
+	return validSubnet.MatchString(id) ||
+		fallbackValidSubnet.MatchString(id)
 }
 
 type SubnetTag struct {

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -39,6 +39,9 @@ var parseSubnetTagTests = []struct {
 	tag:      "subnet-16",
 	expected: names.NewSubnetTag("16"),
 }, {
+	tag:      "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
+	expected: names.NewSubnetTag("0195847b-95bb-7ca1-a7ee-2211d802d5b3"),
+}, {
 	tag: "subnet-foo",
 	err: names.InvalidTagError("subnet-foo", names.SubnetTagKind),
 }, {

--- a/tag.go
+++ b/tag.go
@@ -19,6 +19,9 @@ const (
 	// NumberSnippet is a non-compiled regexp that can be composed with other
 	// snippets for validating small number sequences.
 	NumberSnippet = "(?:0|[1-9][0-9]*)"
+	// UUIDv7Snippet is a non-compiled regexp that can be composed with other
+	// snippets for validating UUID v7 strings.
+	UUIDv7Snippet = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 )
 
 var (


### PR DESCRIPTION
A bug has been discovered recently in Juju 4.0 where we cannot move spaces because the subnet (which is automatically retrieved and inserted into the db with a new UUID v7 as primary key) cannot be passed as a new Subnet tag and therefore it panics.

The fix is to add a new validation regex for spaces and subnets which validate UUIDs v7 and keep the legacy (and deprecated) sequence ID as fallback validation for backward compatibility.

## QA

Run unit tests:
```
$ go test .
```

Also test the changes within Juju:
1) Add the replace statement on Juju's go.mod to point to this unmerged version locally (replace with your path):
```
replace github.com/juju/names/v6 => /home/nicolas/workspace/canonical/names
```
2) `make go-install` Juju
3) Actual QA:
```
$ juju bootstrap lxd c --build-agent
$ juju add-model m
$ juju add-space beta
$ juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.165.241.0/24
                                             10.254.213.0/24
beta   019585a6-b393-7cbe-b131-51bb67af8f52
$ juju subnets
subnets:
  10.165.241.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.165.241.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - newells
  10.254.213.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.254.213.0/24
    provider-network-id: net-mpqemubr0
    space: alpha
    zones:
    - newells
$ juju move-to-space beta 10.254.213.0/24
$ juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.165.241.0/24
beta   019585a6-b393-7cbe-b131-51bb67af8f52  10.254.213.0/24
$ juju subnets
subnets:
  10.165.241.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.165.241.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - newells
  10.254.213.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.254.213.0/24
    provider-network-id: net-mpqemubr0
    space: beta
    zones:
    - newells
```