### PR TITLE
fix: space/subnet tag shouldn't validate against UUIDs

### DIFF
--- a/space.go
+++ b/space.go
@@ -13,16 +13,11 @@ const (
 	SpaceSnippet = "(?:[a-z0-9]+(?:-[a-z0-9]+)*)"
 )
 
-var (
-	validSpace = regexp.MustCompile("^" + UUIDv7Snippet + "$")
-	// Deprecated: Juju 4.0 should have space IDs in the form of UUIDv7.
-	fallbackValidSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
-)
+var validSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
 
 // IsValidSpace reports whether name is a valid space name.
 func IsValidSpace(name string) bool {
-	return validSpace.MatchString(name) ||
-		fallbackValidSpace.MatchString(name)
+	return validSpace.MatchString(name)
 }
 
 type SpaceTag struct {

--- a/space_test.go
+++ b/space_test.go
@@ -58,11 +58,8 @@ var parseSpaceTagTests = []struct {
 	tag: "",
 	err: names.InvalidTagError("", ""),
 }, {
-	tag:      "space-1",
-	expected: names.NewSpaceTag("1"),
-}, {
-	tag:      "space-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
-	expected: names.NewSpaceTag("0195847b-95bb-7ca1-a7ee-2211d802d5b3"),
+	tag:      "space-alpha",
+	expected: names.NewSpaceTag("alpha"),
 }, {
 	tag: "-space1",
 	err: names.InvalidTagError("-space1", ""),

--- a/subnet.go
+++ b/subnet.go
@@ -10,16 +10,11 @@ import (
 
 const SubnetTagKind = "subnet"
 
-var (
-	validSubnet = regexp.MustCompile("^" + UUIDv7Snippet + "$")
-	// Deprecated: Juju 4.0 should have subnet IDs in the form of UUIDv7.
-	fallbackValidSubnet = regexp.MustCompile("^" + NumberSnippet + "$")
-)
+var validSubnet = regexp.MustCompile("^" + UUIDv7Snippet + "$")
 
 // IsValidSubnet returns whether id is a valid subnet id.
 func IsValidSubnet(id string) bool {
-	return validSubnet.MatchString(id) ||
-		fallbackValidSubnet.MatchString(id)
+	return validSubnet.MatchString(id)
 }
 
 type SubnetTag struct {

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -14,7 +14,7 @@ type subnetSuite struct{}
 var _ = gc.Suite(&subnetSuite{})
 
 func (s *subnetSuite) TestNewSubnetTag(c *gc.C) {
-	id := "16"
+	id := "0195847b-95bb-7ca1-a7ee-2211d802d5b3"
 	tag := names.NewSubnetTag(id)
 	parsed, err := names.ParseSubnetTag(tag.String())
 	c.Assert(err, gc.IsNil)
@@ -35,9 +35,6 @@ var parseSubnetTagTests = []struct {
 }{{
 	tag: "",
 	err: names.InvalidTagError("", ""),
-}, {
-	tag:      "subnet-16",
-	expected: names.NewSubnetTag("16"),
 }, {
 	tag:      "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
 	expected: names.NewSubnetTag("0195847b-95bb-7ca1-a7ee-2211d802d5b3"),

--- a/tag_test.go
+++ b/tag_test.go
@@ -42,7 +42,7 @@ var tagKindTests = []struct {
 	{tag: "ipaddress", err: `"ipaddress" is not a valid tag`},
 	{tag: "ipaddress-42424242-1111-2222-3333-0123456789ab", kind: names.IPAddressTagKind},
 	{tag: "subnet", err: `"subnet" is not a valid tag`},
-	{tag: "subnet-16", kind: names.SubnetTagKind},
+	{tag: "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3", kind: names.SubnetTagKind},
 	{tag: "space", err: `"space" is not a valid tag`},
 	{tag: "space-42", kind: names.SpaceTagKind},
 	{tag: "cloud", err: `"cloud" is not a valid tag`},
@@ -224,10 +224,10 @@ var parseTagTests = []struct {
 	tag:       "subnet-",
 	resultErr: `"subnet-" is not a valid subnet tag`,
 }, {
-	tag:        "subnet-16",
+	tag:        "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
 	expectKind: names.SubnetTagKind,
 	expectType: names.SubnetTag{},
-	resultId:   "16",
+	resultId:   "0195847b-95bb-7ca1-a7ee-2211d802d5b3",
 }, {
 	tag:       "space-",
 	resultErr: `"space-" is not a valid space tag`,


### PR DESCRIPTION
In a previous patch, the validation against UUIDs v7 was added for subnets and spaces. It turns out it wasn't needed for spaces since we use the space *name* as a tag in Juju.

This wrong validation was removed and the test was updated to reflect that we use a space name instead of a sequence number.

Also, the fallback validation for sequence numbers in subnets was removed since only uuid-subnets are used in juju 4.0.

# QA

```
$ go test .
```

Also test the changes within Juju:
1) Add the replace statement on Juju's go.mod to point to this unmerged version locally (replace with your path):
```
replace github.com/juju/names/v6 => /home/nicolas/workspace/canonical/names
```
2) `make go-install` Juju
3) Actual QA:
```
$ juju bootstrap lxd c --build-agent
$ juju add-model m
$ juju add-space beta
$ juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.165.241.0/24
                                             10.254.213.0/24
beta   019585a6-b393-7cbe-b131-51bb67af8f52
$ juju subnets
subnets:
  10.165.241.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.165.241.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - newells
  10.254.213.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.254.213.0/24
    provider-network-id: net-mpqemubr0
    space: alpha
    zones:
    - newells
$ juju move-to-space beta 10.254.213.0/24
$ juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.165.241.0/24
beta   019585a6-b393-7cbe-b131-51bb67af8f52  10.254.213.0/24
$ juju subnets
subnets:
  10.165.241.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.165.241.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - newells
  10.254.213.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.254.213.0/24
    provider-network-id: net-mpqemubr0
    space: beta
    zones:
    - newells
```