### PR TITLE
fix: add fallback for spaces and subnets validation

### DIFF
--- a/space.go
+++ b/space.go
@@ -13,11 +13,18 @@ const (
 	SpaceSnippet = "(?:[a-z0-9]+(?:-[a-z0-9]+)*)"
 )
 
-var validSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
+var (
+	validSpace = regexp.MustCompile("^" + UUIDv7Snippet + "$")
+	// Deprecated: Juju 4 should have space IDs in the form of UUIDv7, but we
+	// use this fallback to continue supporting the Juju 4+ client against
+	// Juju 3.x controllers.
+	fallbackValidSpace = regexp.MustCompile("^" + SpaceSnippet + "$")
+)
 
 // IsValidSpace reports whether name is a valid space name.
 func IsValidSpace(name string) bool {
-	return validSpace.MatchString(name)
+	return validSpace.MatchString(name) ||
+		fallbackValidSpace.MatchString(name)
 }
 
 type SpaceTag struct {

--- a/space_test.go
+++ b/space_test.go
@@ -61,6 +61,12 @@ var parseSpaceTagTests = []struct {
 	tag:      "space-alpha",
 	expected: names.NewSpaceTag("alpha"),
 }, {
+	tag:      "space-1",
+	expected: names.NewSpaceTag("1"),
+}, {
+	tag:      "space-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
+	expected: names.NewSpaceTag("0195847b-95bb-7ca1-a7ee-2211d802d5b3"),
+}, {
 	tag: "-space1",
 	err: names.InvalidTagError("-space1", ""),
 }}

--- a/subnet.go
+++ b/subnet.go
@@ -10,11 +10,18 @@ import (
 
 const SubnetTagKind = "subnet"
 
-var validSubnet = regexp.MustCompile("^" + UUIDv7Snippet + "$")
+var (
+	validSubnet = regexp.MustCompile("^" + UUIDv7Snippet + "$")
+	// Deprecated: Juju 4 should have subnet IDs in the form of UUIDv7, but
+	// we use this fallback to continue supporting the Juju 4+ client against
+	// Juju 3.x controllers.
+	fallbackValidSubnet = regexp.MustCompile("^" + NumberSnippet + "$")
+)
 
 // IsValidSubnet returns whether id is a valid subnet id.
 func IsValidSubnet(id string) bool {
-	return validSubnet.MatchString(id)
+	return validSubnet.MatchString(id) ||
+		fallbackValidSubnet.MatchString(id)
 }
 
 type SubnetTag struct {

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -36,6 +36,9 @@ var parseSubnetTagTests = []struct {
 	tag: "",
 	err: names.InvalidTagError("", ""),
 }, {
+	tag:      "subnet-16",
+	expected: names.NewSubnetTag("16"),
+}, {
 	tag:      "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
 	expected: names.NewSubnetTag("0195847b-95bb-7ca1-a7ee-2211d802d5b3"),
 }, {

--- a/tag_test.go
+++ b/tag_test.go
@@ -42,6 +42,7 @@ var tagKindTests = []struct {
 	{tag: "ipaddress", err: `"ipaddress" is not a valid tag`},
 	{tag: "ipaddress-42424242-1111-2222-3333-0123456789ab", kind: names.IPAddressTagKind},
 	{tag: "subnet", err: `"subnet" is not a valid tag`},
+	{tag: "subnet-16", kind: names.SubnetTagKind},
 	{tag: "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3", kind: names.SubnetTagKind},
 	{tag: "space", err: `"space" is not a valid tag`},
 	{tag: "space-42", kind: names.SpaceTagKind},
@@ -223,6 +224,11 @@ var parseTagTests = []struct {
 }, {
 	tag:       "subnet-",
 	resultErr: `"subnet-" is not a valid subnet tag`,
+}, {
+	tag:        "subnet-16",
+	expectKind: names.SubnetTagKind,
+	expectType: names.SubnetTag{},
+	resultId:   "16",
 }, {
 	tag:        "subnet-0195847b-95bb-7ca1-a7ee-2211d802d5b3",
 	expectKind: names.SubnetTagKind,


### PR DESCRIPTION
This patch adds back a fallback for validating legacy space and subnet formats.
This fallback was added first in https://github.com/juju/names/pull/118 then incorrectly removed in https://github.com/juju/names/pull/119 and now it's added back again. The reason is that if a 4+ Juju client tries to `move-to-space` on a 3.x controller, the client will panic. This fallback prevents that.

# QA

Run unit tests:
```
$ go test .
```

Also test the changes within Juju:
1) Add the replace statement on Juju's go.mod to point to this unmerged version locally (replace with your path):
```
replace github.com/juju/names/v6 => /home/nicolas/workspace/canonical/names
```
2) `make go-install` Juju
3) Install Juju 3.6 snap (if needed): 
```
sudo snap install juju_36 --channel 3.6/stable
```
4) Actual QA:
```
$ juju_36 bootstrap lxd c
$ juju_36 add-model m
$ juju_36 add-space beta
# Now move spaces using the current client:
$ juju move-to-space beta 10.254.213.0/24
```
The last command should work and not panic.